### PR TITLE
Cache hashed Nuxt assets forever

### DIFF
--- a/src/static/_headers
+++ b/src/static/_headers
@@ -12,6 +12,6 @@
 # All Nuxt files are hashed and can be cached forever
 # docs: https://nuxtjs.org/api/configuration-build/#filenames
 #       https://www.netlify.com/docs/headers-and-basic-auth/#multi-key-header-rules
-/_nuxt/
+/_nuxt/*
   Cache-Control: max-age=365000000
   Cache-Control: immutable


### PR DESCRIPTION
All Nuxt files are hashed and can be cached forever, boosting performance of repeat views.