### PR TITLE
Remove hidden social share buttons from normal keyboard tabbing order

### DIFF
--- a/src/components/social-share/social-share.vue
+++ b/src/components/social-share/social-share.vue
@@ -18,6 +18,7 @@
       :aria-hidden="!optionsAreVisible"
     >
       <a
+        :tabindex="optionsAreVisible ? 0 : -1"
         v-for="(platform, index) in platforms"
         :key="index"
         :href="`${platform.link}${encodedUrl}`"
@@ -35,9 +36,9 @@
       </a>
 
       <button
+        :tabindex="optionsAreVisible ? 0 : -1"
         v-if="copyToClipboardIsVisible"
         @click="copyToClipboard"
-        :aria-hidden="!optionsAreVisible"
         class="social-share__option button button--round"
         :class="{ 'social-share__option--visible' : optionsAreVisible }"
         ref="copyButton"


### PR DESCRIPTION
TIL aria-hidden does not remove an element from the normal element flow: https://stackoverflow.com/questions/52204588/aria-hidden-true-on-parent-does-not-make-its-children-also-aria-hidden

I did keep aria-hidden on the parent element to indicate the collapsed share buttons are not visible.