### PR TITLE
Redirect default Netlify subdomain to primary domain

### DIFF
--- a/src/static/_redirects
+++ b/src/static/_redirects
@@ -1,3 +1,6 @@
+# Redirect default Netlify subdomain to primary domain
+https://spacefinder.netlify.com/* https://spacefinder.tudelft.nl/:splat 301!
+
 # Redirect to preferred locale, default to English:
 / /nl/ 302 Language=nl
 / /en/ 302


### PR DESCRIPTION
Per Netlify's recipe:
> If for SEO reasons you want to redirect your default Netlify subdomain to the primary domain, you can do so by adding the following rules to a _redirects file in the root of your site folder.