### PR TITLE
Experiment with Netlify timeout

### DIFF
--- a/config/nuxt/build.js
+++ b/config/nuxt/build.js
@@ -2,23 +2,6 @@
  * @see https://nuxtjs.org/api/configuration-build
  */
 module.exports = {
-  html: {
-    /**
-     * Overwrite default config to skip minification of CSS & JS to speed up build
-     * default: https://github.com/nuxt/nuxt.js/blob/5fa768373da1adfd8c76145b2ec95b7824af93b4/packages/config/src/config/build.js#L93-L94
-     */
-    minify: {
-      collapseBooleanAttributes: true,
-      decodeEntities: true,
-      minifyCSS: false,
-      minifyJS: false,
-      processConditionalComments: true,
-      removeEmptyAttributes: true,
-      removeRedundantAttributes: true,
-      trimCustomFragments: true,
-      useShortDoctype: true
-    }
-  },
   postcss: {
     'postcss-import': {},
     'postcss-custom-properties': {

--- a/config/nuxt/generate.js
+++ b/config/nuxt/generate.js
@@ -4,6 +4,7 @@ import routes from '../routes'
  * @see https://nuxtjs.org/api/configuration-generate
  */
 export default {
+  concurrency: 1,
   dir: 'dist/client/',
   routes
 }


### PR DESCRIPTION
Generating all 833 pages took 5h33m21s on my local machine (timed w/ `time npm run build`). I expect Netlify to time out well before then.