### PR TITLE
Add basic offline app experience

### DIFF
--- a/config/nuxt/modules/nuxt-pwa.js
+++ b/config/nuxt/modules/nuxt-pwa.js
@@ -1,3 +1,4 @@
+const startPage = '/200.html'
 /**
  * @see https://pwa.nuxtjs.org
  */
@@ -10,9 +11,16 @@ export default [
       background_color: '#00a6d6',
       theme_color: '#00a6d6',
       display: 'standalone',
-      crossorigin: 'use-credentials'
+      crossorigin: 'use-credentials',
+      start_url: `${startPage}?utm_source=homescreen`
+    },
+    meta: {
+      mobileApp: true,
+      mobileAppIOS: true
     },
     workbox: {
+      preCaching: [startPage],
+      offlinePage: startPage,
       runtimeCaching: [
         {
           urlPattern: 'https://www.datocms-assets.com/.*',


### PR DESCRIPTION
The `200.html` page is the fallback page generated by Nuxt.
The app now has a valid `start_url` and now has an offline fallback page using that `200.html`.

[**before**](https://spacefinder.tudelft.nl/): (installable, not reliable offline)

![Screen Shot 2019-08-13 at 22 55 11](https://user-images.githubusercontent.com/1516059/62976689-794e1480-be1d-11e9-92f7-a6496fc077c1.jpg)


[**after**](https://deploy-preview-95--spacefinder.netlify.com/): (installable and reliable)

![Screen Shot 2019-08-13 at 22 52 40](https://user-images.githubusercontent.com/1516059/62976572-2ffdc500-be1d-11e9-9ecb-bb262f8b244b.jpg)
