### PR TITLE
Use modern bundles for modern browsers

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -13,6 +13,7 @@ export default {
   head,
   loading: { color: '#fff' },
   mode: 'universal',
+  modern: 'client',
   modules,
   plugins: [
     '~/plugins/install-prompt.client',


### PR DESCRIPTION
https://nuxtjs.org/api/configuration-modern/

other browsers still get transpiled bundles

default bundle sizes (gzipped) | modern bundles sizes (gzipped)
--- | ---
All (306.43 KB) | All (297.68 KB)
vendors.mapboxgl.js (175.04 KB) | modern-vendors.mapboxgl.js (175.04 KB)
commons.app.js (55.01 KB) | modern-commons.app.js (48.46 KB)
app.js (32.9 KB) | modern-app.js (30.69 KB)
vendors.app.js (17.72 KB) | modern-vendors.app.js (17.77 KB)
lang-spaces.js (12.76 KB) | modern-lang-spaces.js (12.76 KB)
pages/buildings/_buildingSlug/spaces/_spaceSlug.js (2.13 KB) | modern-pages/buildings/_buildingSlug/spaces/_spaceSlug.js (2.12 KB)
lang-buildings.js (2.02 KB) | modern-lang-buildings.js (2.02 KB)
16.js (1.69 KB) | modern-16.js (1.69 KB)
pages/buildings/_buildingSlug/index.js (1.28 KB) | modern-pages/buildings/_buildingSlug/index.js (1.27 KB)
runtime.js (1.21 KB) | modern-runtime.js (1.22 KB)
lang-nl-messages.js (1.15 KB) | modern-lang-nl-messages.js (1.15 KB)
pages/buildings/index.js (1.08 KB) | modern-pages/buildings/index.js (1.06 KB)
lang-en-messages.js (1.03 KB) | modern-lang-en-messages.js (1.03 KB)
pages/index.js (693 B) | modern-pages/index.js (684 B)
pages/404.js (275 B) | modern-pages/404.js (274 B)
pages/buildings/_buildingSlug/spaces/index.js (249 B) | modern-pages/buildings/_buildingSlug/spaces/index.js (244 B)
mapboxgl.js (235 B) | modern-mapboxgl.js (235 B)

Stats acquired using `npm run analyze`.