### PR TITLE
Disable language browser detection

### DIFF
--- a/config/nuxt/modules/nuxt-i18n.js
+++ b/config/nuxt/modules/nuxt-i18n.js
@@ -9,10 +9,7 @@ export default [
   'nuxt-i18n',
   {
     defaultLocale,
-    detectBrowserLanguage: {
-      useCookie: true,
-      cookieKey: 'nf_lang', // https://www.netlify.com/docs/redirects/#geoip-and-language-based-redirects
-    },
+    detectBrowserLanguage: false,
     lazy: true,
     langDir: 'static/data/',
     locales: locales.map((locale) => {

--- a/src/pages/tips.vue
+++ b/src/pages/tips.vue
@@ -2,6 +2,7 @@
   <section class="default-layout__info default-layout__info--info-page">
     <h1>{{ title }}</h1>
 
+    <!-- eslint-disable-next-line vue/no-v-html -->
     <div v-html="body" />
   </section>
 </template>


### PR DESCRIPTION
Disable the browser language detection because it causes bugs when loading the website for the first time which I couldn't fix in time. The whole setup is quite complex and custom-made as far as I can see. 

## Bugs
1. On the homepage switching the language caused the page to switch URL but not switch language.
2. On a space page that is not the browser language switching the first time throws an error.

Hacky script to automate testing the first bug (check the screenshot output and run with `node --experimental-modules puppy.mjs`):
```js
import puppeteer from 'puppeteer-core';

puppeteer
.launch({
  executablePath: '/usr/bin/chromium-browser',
})
.then(async browser => {
  const page = await browser.newPage();
  await page.goto('http://localhost:3463/en/');
  const headerButton = await page.$$('button.app-header__button');
  await headerButton[1].click();
  
  const link = await page.$$('a.app-menu__link');
  await link[3].click();
  await delay(1000);
  await page.screenshot({path: 'screenshot.png'});
  await browser.close();
});

function delay(time) {
   return new Promise(function(resolve) { 
       setTimeout(resolve, time)
   });
}
```

## Attempted fixes
- Update `nuxt-i18n` to it's latest 6.x version and updating the config accordingly:
```
vuex: {
  syncLocale: true,
},
```
- Run `this.$i18n.setLocaleCookie(locale)` when clicking on the `nuxt-link` in the `language-selector`
- Disabling and enabling various parts of the i18n plugin in `nuxt-i18n`
