### PR TITLE
Implement new design for number of seats in space cards

### DIFF
--- a/src/components/app-core/typography.css
+++ b/src/components/app-core/typography.css
@@ -29,10 +29,6 @@ h3,
   font-weight: 500;
 }
 
-p:not(:last-child) {
-  margin-bottom: var(--spacing-default);
-}
-
 a {
     color: var(--text-color);
     text-decoration: underline;

--- a/src/components/space-card/space-card.vue
+++ b/src/components/space-card/space-card.vue
@@ -8,11 +8,12 @@
     "
     class="space-card card"
   >
+    <h3 v-if="space.name">
+      {{ space.name }}
+    </h3>
+
     <div class="space-card__info">
       <div class="space-card__location">
-        <h3 v-if="space.name">
-          {{ space.name }}
-        </h3>
         <p
           v-if="space.name"
           class="space-card__description"
@@ -24,31 +25,29 @@
         </h3>
       </div>
 
-      <h4 class="a11y-sr-only">
-        {{ $t('seating') }}
-      </h4>
-
-      <div class="flat-list space-card__seating">
-        <svg-icon name="seat-icon" class="space-card__seating-icon" />
-        {{ space.seats }}
-      </div>
-    </div>
-
-    <div class="space-card__meta">
       <card-status
         :opening-hours="space.openingHours"
         :is-open="locationIsOpen"
         class="space-card__status"
       />
+    </div>
 
-      <h4 class="a11y-sr-only">
-        {{ $t('facilities') }}
-      </h4>
+    <h4 class="a11y-sr-only">
+      {{ $t('facilities') }}
+    </h4>
 
-      <space-facilities
-        :facilities="space.facilities"
-        class="space-card__facilities"
-      />
+    <space-facilities
+      :facilities="space.facilities"
+      class="space-card__facilities"
+    />
+
+    <h4 class="a11y-sr-only">
+      {{ $t('seating') }}
+    </h4>
+
+    <div class="space-card__seating">
+      <svg-icon name="seat-icon" class="space-card__seating-icon" />
+      {{ space.seats }} {{ $t('seatsDescription') }}
     </div>
   </nuxt-link>
 </template>
@@ -105,38 +104,22 @@ export default {
   font-style: normal;
 }
 
-.space-card__seating {
+.space-card__status {
   flex: 0 0 auto;
-  margin-left: var(--spacing-default);
-  font-size: var(--font-size-smaller);
-  font-weight: bold;
 }
 
-.space-card__seating li {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+.space-card__facilities {
+  margin-left: -.2rem;
+}
+
+.space-card__seating {
+  font-size: var(--font-size-smaller);
 }
 
 .space-card__seating-icon {
   margin: -2px 1px 0 0;
-  width: 18px;
-  height: 18px;
+  width: 16px;
+  height: 16px;
   vertical-align: middle;
-}
-
-.space-card__meta {
-  display: flex;
-}
-
-.space-card__status {
-  order: 2;
-  flex: 0 0 auto;
-  margin-top: .1rem;
-}
-
-.space-card__facilities {
-  order: 1;
-  flex: 1 1 auto;
 }
 </style>

--- a/src/components/space-card/space-card.vue
+++ b/src/components/space-card/space-card.vue
@@ -47,7 +47,7 @@
 
     <div class="space-card__seating">
       <svg-icon name="seat-icon" class="space-card__seating-icon" />
-      {{ space.seats }} {{ $t('seatsDescription') }}
+      {{ space.seats }} {{ $t('seatsDescriptionShort') }}
     </div>
   </nuxt-link>
 </template>

--- a/src/components/space-detail-card/space-detail-card.vue
+++ b/src/components/space-detail-card/space-detail-card.vue
@@ -15,13 +15,21 @@
         {{ space.name }}
       </h2>
 
-      <p class="space-detail-card__description">
-        <em>{{ space.building.name }}</em> - {{ space.roomId }}
-      </p>
+      <div class="space-detail-card__info">
+        <div class="space-detail-card__location">
+          <p class="space-detail-card__description">
+            <em>{{ space.building.name }}</em> - {{ space.roomId }}
+          </p>
 
-      <p class="space-detail-card__location">
-        {{ space.floor }}
-      </p>
+          <p>{{ space.floor }}</p>
+        </div>
+
+        <card-status
+          :opening-hours="space.openingHours"
+          :is-open="space.locationIsOpen"
+          class="space-detail-card__open-status"
+        />
+      </div>
     </div>
 
     <div class="space-detail-card__meta">
@@ -32,14 +40,8 @@
 
       <div class="flat-list space-detail-card__seating">
         <svg-icon name="seat-icon" class="space-detail-card__seating-icon" />
-        {{ space.seats }}
+        {{ space.seats }} {{ $t('seatsDescription') }}
       </div>
-
-      <card-status
-        :opening-hours="space.openingHours"
-        :is-open="space.locationIsOpen"
-        class="space-detail-card__open-status"
-      />
 
       <opening-hours
         :opening-hours="space.openingHours"
@@ -81,15 +83,13 @@ export default {
 @media (min-width: 400px) {
   .space-detail-card {
     --image-width: 120px;
-
-    display: flex;
-    flex-wrap: wrap;
   }
 }
 
 @media (min-width: 700px) {
   .space-detail-card {
-    padding: 0;
+    margin: var(--spacing-default-negative);
+    padding: var(--spacing-default);
     background: none;
     box-shadow: none;
   }
@@ -112,24 +112,22 @@ export default {
   .space-detail-card__image {
     position: relative;
     margin: var(--spacing-default-negative) var(--spacing-default-negative) var(--spacing-half) var(--spacing-default-negative);
-    width: calc(100% + 2 * var(--spacing-default));
+    width: calc(100% + var(--spacing-double));
     height: 150px;
   }
 }
 
 .space-detail-card__heading {
-  flex: 1 1 100%;
-  margin-bottom: var(--spacing-double);
+  margin-bottom: var(--spacing-default);
   line-height: 1.5;
 }
 
 .space-detail-card--image .space-detail-card__heading {
-  margin: 0 0 var(--spacing-double) var(--image-width);
+  margin: 0 0 var(--spacing-default) var(--image-width);
 }
 
 @media (min-width: 700px) {
   .space-detail-card__heading {
-    flex: 0 0 75%;
     margin: 0 0 var(--spacing-default) 0;
     line-height: 1.7;
   }
@@ -139,7 +137,12 @@ export default {
   }
 }
 
+.space-detail-card__info {
+  display: flex;
+}
+
 .space-detail-card__title {
+  margin-bottom: 0;
   line-height: 1.3;
   font-size: var(--font-size-default);
   font-weight: 500;
@@ -157,94 +160,56 @@ export default {
 }
 
 .space-detail-card__location {
+  flex: 1 1 auto;
   font-size: var(--font-size-smaller);
   font-weight: bold;
-}
-
-.space-detail-card__meta {
-  display: flex;
-  flex: 1 1 100%;
-  flex-wrap: wrap;
-  justify-content: space-between;
 }
 
 .space-detail-card--image .space-detail-card__meta {
   margin-left: var(--image-width);
 }
 
-.space-detail-card__facilities {
-  flex: 1 1 auto;
-  margin: 0 0 var(--spacing-half) 0;
-}
-
 @media (min-width: 700px) {
-  .space-detail-card__facilities {
-    flex: 1 1 auto;
+  .space-detail-card--image .space-detail-card__meta {
+    margin-left: 0;
   }
 }
 
+.space-detail-card__facilities {
+  margin-left: -.2rem;
+}
+
 .space-detail-card__open-status {
-  flex: 0 0 100%;
+  flex: 0 0 auto;
   font-size: var(--font-size-smaller);
   text-align: right;
 }
 
-@media (min-width: 700px) {
-  .space-detail-card__open-status {
-    position: absolute;
-    margin-top: .1rem;
-    top: var(--spacing-default);
-    right: var(--spacing-default);
-  }
-
-  .space-detail-card--image .space-detail-card__open-status {
-    top: 165px;
-  }
-}
-
-.space-detail-card__open-status--open {
-  color: var(--brand-secondary-color);
-}
-
-.space-detail-card__open-status-icon {
-  width: 11px;
-  height: 11px;
-  stroke: var(--text-color);
-}
-
-.space-detail-card__open-status--open .space-detail-card__open-status-icon {
-  stroke: var(--brand-secondary-color);
-}
-
 .space-detail-card__seating {
-  flex: 0 0 auto;
-  margin-top: 3px;
+  margin-bottom: var(--spacing-default);
   font-size: var(--font-size-smaller);
-  font-weight: bold;
 }
 
 @media (min-width: 700px) {
   .space-detail-card__seating {
-    margin-right: 0;
+    margin-bottom: var(--spacing-double);
   }
-}
-
-.space-detail-card__seating li {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
 }
 
 .space-detail-card__seating-icon {
   margin: -2px 1px 0 0;
-  width: 18px;
-  height: 18px;
+  width: 16px;
+  height: 16px;
   vertical-align: middle;
 }
 
 .space-detail-card__opening-hours {
-  flex: 0 0 100%;
   font-size: var(--font-size-smaller);
+  text-align: left;
+}
+
+.space-detail-card__opening-hours .opening-hours__toggle {
+  margin: 0 0 0 var(--spacing-half-negative);
 }
 
 @media (min-width: 700px) {

--- a/src/static/data/en/messages.json
+++ b/src/static/data/en/messages.json
@@ -62,6 +62,7 @@
   "sa": "Saturday",
   "seating": "Seating",
   "seats": "seats",
+  "seatsDescription": "seats in this space",
   "shareWithTelegram": "Share via Telegram",
   "shareWithWhatsApp": "Share via WhatsApp",
   "showLocations": "show 0 locations | show 1 location | show {amount} locations",

--- a/src/static/data/en/messages.json
+++ b/src/static/data/en/messages.json
@@ -63,6 +63,7 @@
   "seating": "Seating",
   "seats": "seats",
   "seatsDescription": "seats in this space",
+  "seatsDescriptionShort": "seats",
   "shareWithTelegram": "Share via Telegram",
   "shareWithWhatsApp": "Share via WhatsApp",
   "showLocations": "show 0 locations | show 1 location | show {amount} locations",

--- a/src/static/data/nl/messages.json
+++ b/src/static/data/nl/messages.json
@@ -63,6 +63,7 @@
   "seating": "Zitplaatsen",
   "seats": "zitplaatsen",
   "seatsDescription": "zitplaatsen op deze locatie",
+  "seatsDescriptionShort": "zitplaatsen",
   "shareWithTelegram": "Deel via Telegram",
   "shareWithWhatsApp": "Deel via WhatsApp",
   "showLocations": "toon 0 locaties | toon 1 locatie  | toon {count} locaties",

--- a/src/static/data/nl/messages.json
+++ b/src/static/data/nl/messages.json
@@ -62,6 +62,7 @@
   "sa": "zaterdag",
   "seating": "Zitplaatsen",
   "seats": "zitplaatsen",
+  "seatsDescription": "zitplaatsen op deze locatie",
   "shareWithTelegram": "Deel via Telegram",
   "shareWithWhatsApp": "Deel via WhatsApp",
   "showLocations": "toon 0 locaties | toon 1 locatie  | toon {count} locaties",


### PR DESCRIPTION
[Trello ticket](https://trello.com/c/UqcvgrYG/207-wijzigen-weergave-van-aantal-stoelen)

For both space-card and space-detail-card:
- Move opening hours to the same line as space location
- Place number of seats below the facilities icons
- Clean up some unused css for the open status icon in space-detail-card