### PR TITLE
fix: removed noindex property from the head of the site.

### DIFF
--- a/config/nuxt/head.js
+++ b/config/nuxt/head.js
@@ -7,7 +7,6 @@ export default {
     { charset: 'utf-8' },
     { name: 'viewport', content: 'width=device-width, initial-scale=1' },
     { name: 'theme-color', content: '#00a6d6' },
-    { name: 'robots', content: 'noindex' }, // https://support.google.com/webmasters/answer/93710?hl=en
   ],
   link: [
     { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },


### PR DESCRIPTION
Removed the nuxt config property 'robots noindex' from the head, so that the spacefinder app will be indexed by Google.