### PR TITLE
chore: add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,8 +23,6 @@ Resolves https://trello.com/c/oYgBIyqt/2-document-architecture-change-in-decisio
 
 <!-- Please strike through and check off all items that do not apply (rather than removing them) -->
 
-- [ ] I have performed a self-review of my own code
+- [ ] I have performed a self-review of my own work
 - [ ] I have made sure that my PR is easy to review (not too big, includes comments)
-- [ ] I have added/updated tests to prove that my feature works (if not possible please explain why)
-- [ ] I have made changes to the README if the change affects the architecture of the project (npm commands changed, new service added, environmental variable added)
 - [ ] I have notified a reviewer

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+# Changes
+
+<!-- example:
+- Fix wrong color in button
+- Add a new page
+-->
+
+# Associated issue
+
+<!-- example:
+Resolves https://trello.com/c/oYgBIyqt/2-document-architecture-change-in-decision-log
+-->
+
+# How to test
+
+<!-- example:
+1. Open preview link: https://...
+2. Click on *x*
+3. Verify the button is red
+-->
+
+# Checklist
+
+<!-- Please strike through and check off all items that do not apply (rather than removing them) -->
+
+- [ ] I have performed a self-review of my own code
+- [ ] I have made sure that my PR is easy to review (not too big, includes comments)
+- [ ] I have added/updated tests to prove that my feature works (if not possible please explain why)
+- [ ] I have made changes to the README if the change affects the architecture of the project (npm commands changed, new service added, environmental variable added)
+- [ ] I have notified a reviewer


### PR DESCRIPTION
# Changes

Adds default PR template, based on [Voorhoede PR template](https://github.com/voorhoede/.github/blob/main/PULL_REQUEST_TEMPLATE/internal-projects.md) to encourage better PR's that are easier to review.

# Associated issue

N/A

# How to test

See that it was automatically appended to this PR. Also see GitHub docs: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository .

# Checklist

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->

- [x] I have performed a self-review of my own "code"
- [x] ~~I have made sure that my PR is easy to review (not too big, includes comments)~~
- [x] ~~I have added/updated tests to prove that my feature works (if not possible please explain why)~~
- [x] ~~I have made changes to the README if the change affects the architecture of the project (npm commands changed, new service added, environmental variable added)~~
- [x] I have notified a reviewer
