### PR TITLE
fix: useMediaQuery cannot be used directly in plugin

### DIFF
--- a/src/plugins/view-mode.ts
+++ b/src/plugins/view-mode.ts
@@ -1,5 +1,7 @@
 export default defineNuxtPlugin((nuxtApp) => {
   const isMobile = ref(false);
+  // Lifecycle-dependend composables like useMediaQuery cannot be used directly during plugin setup
+  // so we wait for the Vue app to be mounted
   nuxtApp.hook("app:mounted", () => {
     watchEffect(() => {
       isMobile.value = !useMediaQuery("(min-width: 700px)").value;

--- a/src/plugins/view-mode.ts
+++ b/src/plugins/view-mode.ts
@@ -1,7 +1,13 @@
-export default defineNuxtPlugin(() => {
+export default defineNuxtPlugin((nuxtApp) => {
+  const isMobile = ref(false);
+  nuxtApp.hook("app:mounted", () => {
+    watchEffect(() => {
+      isMobile.value = !useMediaQuery("(min-width: 700px)").value;
+    });
+  });
   return {
     provide: {
-      isMobile: computed(() => !useMediaQuery("(min-width: 700px)").value),
+      isMobile: computed(() => isMobile.value),
       isMapMode: ref(false),
     },
   };


### PR DESCRIPTION
This lead to invalid result on the server (isMobile was reported as true), a hydration mismatch and a warning upon an incorrect composable usage on the client