### PR TITLE
fix: value provided from nuxt plugin used in script

### DIFF
--- a/src/components/AppMenu/AppMenu.vue
+++ b/src/components/AppMenu/AppMenu.vue
@@ -95,7 +95,8 @@ import { useInstallationStore } from "~/stores/installation";
 
 defineProps<{ isOpen?: boolean }>();
 const emit = defineEmits(["close"]);
-const { $isMapMode } = useNuxtApp();
+//Without local rename $isMapMode overrides the one that is auto-available in the template and since it's a component-local ref it starts being accessible without .value, which is misleading
+const { $isMapMode: isMapMode } = useNuxtApp();
 const installationStore = useInstallationStore();
 
 const { isInstallable } = storeToRefs(installationStore);
@@ -105,7 +106,7 @@ function installApp() {
 }
 
 function toggleMapMode() {
-  $isMapMode.value = !$isMapMode.value;
+  isMapMode.value = !isMapMode.value;
   emit("close");
 }
 </script>


### PR DESCRIPTION
# Changes

- Fix map/location list switch label in menu

# Associated issue

# How to test

1. Open the app in a mobile-sized viewport
2. Switch between map and location list in the menu
3. See the table of the corresponding command change correctly

# Checklist

- [x] I have performed a self-review of my own work
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have notified a reviewer
