### PR TITLE
fix: menu button color

### DIFF
--- a/src/components/app-core/buttons.css
+++ b/src/components/app-core/buttons.css
@@ -22,6 +22,7 @@
 .button--header:hover,
 .button--header:focus {
     border: 1px solid var(--background-color);
+    color: var(--background-color);
 }
 
 @media (min-width: 700px) {


### PR DESCRIPTION
# Changes

- Menu buttons don't change color on hover

# Associated issue

# How to test

1. Hover the menu and filter buttons and see their text not change color to black

- [x] I have performed a self-review of my own work
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have notified a reviewer
