### PR TITLE
feat: no device count in occupancy tooltip

### DIFF
--- a/src/components/OccupancyIndicator/OccupancyIndicator.vue
+++ b/src/components/OccupancyIndicator/OccupancyIndicator.vue
@@ -8,7 +8,7 @@
           :alt="$t(`occupancy.${occupancy}`)"
         />
         <template #popper>
-          {{ $t("activeDevices") }}: {{ activeDevices }}
+          {{ $t("occupancy") }}: {{ $t(`occupancy.${occupancy}`) }}
         </template>
       </Tooltip>
     </div>


### PR DESCRIPTION
# Changes

- Occupancy tooltips display a text describing their icon instead of device count

# Associated issue

Resolves https://trello.com/c/NgwDKGDp/37-occupancy-tooltips

# How to test

1. Hover over occupancy indicators and observe localised text corresponding to the icon

# Checklist

- [x] I have performed a self-review of my own work
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have notified a reviewer
