### PR TITLE
fix: correct i18n key for occupancy

### DIFF
--- a/src/components/OccupancyIndicator/OccupancyIndicator.vue
+++ b/src/components/OccupancyIndicator/OccupancyIndicator.vue
@@ -8,7 +8,7 @@
           :alt="$t(`occupancy.${occupancyKey}`)"
         />
         <template #popper>
-          {{ $t("occupancy") }}: {{ $t(`occupancy.${occupancy}`) }}
+          {{ $t("occupancy") }}: {{ $t(`occupancy.${occupancyKey}`) }}
         </template>
       </Tooltip>
     </div>


### PR DESCRIPTION
# Changes

- Fix i18n key for unknown occupancy in the indicator

# Associated issue

<!-- example:
Resolves https://trello.com/c/oYgBIyqt/2-document-architecture-change-in-decision-log
-->

# How to test

1. The grey indicator says "unknown", not "occupancy.undefined"

# Checklist

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->

- [x] I have performed a self-review of my own work
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have notified a reviewer
