### PR TITLE
fix: reactivity was lost in the buildings list page

### DIFF
--- a/src/pages/[locale]/buildings/index.vue
+++ b/src/pages/[locale]/buildings/index.vue
@@ -18,13 +18,13 @@ import { useMapStore } from "~/stores/map";
 
 definePageMeta({ alias: "/:locale/gebouwen" });
 
-const { buildings } = useSpacesStore();
+const spacesStore = useSpacesStore();
 
 const mapStore = useMapStore();
 const { $t } = useNuxtApp();
 
 const buildingsOrdered = computed(() =>
-  [...buildings].sort((a, b) => a.name.localeCompare(b.name))
+  [...spacesStore.buildings].sort((a, b) => a.name.localeCompare(b.name))
 );
 
 const title = computed(() => $t("buildingTitle"));


### PR DESCRIPTION
# Changes

- Reactivity was lost for the building list - data modified in the store (e.g. occupancy) did not cause it to refresh
# Associated issue

<!-- example:
Resolves https://trello.com/c/oYgBIyqt/2-document-architecture-change-in-decision-log
-->

# How to test

1. Open the buildings page
2. Modify data in buildings_current_states so that occupancy changes
3. Verify not only the color of the marker but also the indicator in the list changes

# Checklist

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->

- [x] I have performed a self-review of my own work
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have notified a reviewer
