### PR TITLE
Fix overflow on page when scrolling in spaces list due to virtual scrolling

### DIFF
--- a/src/components/app-core/layout.css
+++ b/src/components/app-core/layout.css
@@ -8,6 +8,10 @@ html {
     background-color: var(--mapbox-background-color);
 }
 
+body {
+    overflow-y: hidden;
+}
+
 .default-layout {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
# Changes
Overflow.

<!-- example:
- Fix wrong color in button
- Add a new page
-->

# Associated issue
https://trello.com/c/ThlQvUcw/41-layout-on-desktop-jumps-when-selecting-a-building-in-filter-menu

<!-- example:
Resolves https://trello.com/c/oYgBIyqt/2-document-architecture-change-in-decision-log
-->

# How to test
Scroll in the room list (right side) and open the filter, scrolling down on the body does not cause a grey area to appear on the bottom of the page.
<!-- example:
1. Open preview link: https://...
2. Click on *x*
3. Verify the button is red
-->

# Checklist

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->

- [ ] I have performed a self-review of my own work
- [ ] I have made sure that my PR is easy to review (not too big, includes comments)
- [ ] I have notified a reviewer
