### PR TITLE
Fetch occupancy data instead of using realtime changes

### DIFF
--- a/src/composables/useSpacefinderSupabase.ts
+++ b/src/composables/useSpacefinderSupabase.ts
@@ -18,25 +18,6 @@ export default function useSpacefinderSupabase() {
     return data;
   }
 
-  function subscribeToBuildingsOccupancy(
-    callback: (buildingNumber: number, deviceCount: number | undefined) => void
-  ) {
-    const buildingsRealtimeChannel = client
-      .channel("buildings")
-      .on(
-        "postgres_changes",
-        { event: "*", schema: "public", table: "buildings_latest_states" },
-        ({ eventType, new: newData, old }) => {
-          if (eventType == "UPDATE" || eventType == "INSERT") {
-            callback(newData.building_number, newData.device_count);
-          } else {
-            callback(old.building_number, undefined);
-          }
-        }
-      );
-    buildingsRealtimeChannel.subscribe();
-  }
-
   async function getSpacesOccupancyCurrent() {
     const { data } = await client
       .from("spaces_latest_states")
@@ -45,32 +26,8 @@ export default function useSpacefinderSupabase() {
     return data;
   }
 
-  function subscribeToSpacesOccupancy(
-    callback: (
-      realEstateNumber: string,
-      deviceCount: number | undefined
-    ) => void
-  ) {
-    const spacesRealtimeChannel = client
-      .channel("spaces")
-      .on(
-        "postgres_changes",
-        { event: "*", schema: "public", table: "spaces_latest_states" },
-        ({ eventType, new: newData, old }) => {
-          if (eventType == "UPDATE" || eventType == "INSERT") {
-            callback(newData.room_id, newData.device_count);
-          } else {
-            callback(old.room_id, undefined);
-          }
-        }
-      );
-    spacesRealtimeChannel.subscribe();
-  }
-
   return {
     getBuildingsOccupancyCurrent,
-    subscribeToBuildingsOccupancy,
     getSpacesOccupancyCurrent,
-    subscribeToSpacesOccupancy,
   };
 }

--- a/src/plugins/load-occupancy-data.client.ts
+++ b/src/plugins/load-occupancy-data.client.ts
@@ -1,31 +1,44 @@
 import type { Pinia } from "pinia";
+import { useTimeoutPoll, useDocumentVisibility, refThrottled } from "@vueuse/core";
 import { useSpacesStore } from "~/stores/spaces";
 import { asDictionary } from "../lib/collection-utils";
 
 export default defineNuxtPlugin(async (app) => {
   const spacesStore = useSpacesStore(app.$pinia as Pinia);
   const supabase = useSpacefinderSupabase();
+  // prevent updating often due to switching tabs
+  const documentVisibility = refThrottled(useDocumentVisibility(), 1000 * 60 * 2);
 
-  const buildingsOccupancy = await supabase.getBuildingsOccupancyCurrent();
-  const activeDevicesPerBuilding = asDictionary(
-    buildingsOccupancy ?? [],
-    "building_number",
-    "device_count"
+  const { pause, resume } = useTimeoutPoll(updateOccupancyData, 1000 * 60 * 5);
+
+  watch(
+    documentVisibility,
+    (documentVisibilityState) => {
+      if (documentVisibilityState === "visible") {
+        resume();
+      } else {
+        pause();
+      }
+    },
+    { immediate: true },
   );
 
-  spacesStore.bulkSetBuildingOccupancy(activeDevicesPerBuilding);
-  supabase.subscribeToBuildingsOccupancy((buildingNumber, deviceCount) =>
-    spacesStore.setBuildingOccupancy(buildingNumber, deviceCount)
-  );
+  async function updateOccupancyData() {
+    const buildingsOccupancy = await supabase.getBuildingsOccupancyCurrent();
+    const activeDevicesPerBuilding = asDictionary(
+      buildingsOccupancy ?? [],
+      "building_number",
+      "device_count"
+    );
 
-  const roomOccupancy = await supabase.getSpacesOccupancyCurrent();
-  const activeDevicesPerRoom = asDictionary(
-    roomOccupancy ?? [],
-    "room_id",
-    "device_count"
-  );
-  spacesStore.bulkSetRoomOccupancy(activeDevicesPerRoom);
-  supabase.subscribeToSpacesOccupancy((realEstateNumber, deviceCount) =>
-    spacesStore.setRoomOccupancy(realEstateNumber, deviceCount)
-  );
+    spacesStore.bulkSetBuildingOccupancy(activeDevicesPerBuilding);
+
+    const roomOccupancy = await supabase.getSpacesOccupancyCurrent();
+    const activeDevicesPerRoom = asDictionary(
+      roomOccupancy ?? [],
+      "room_id",
+      "device_count"
+    );
+    spacesStore.bulkSetRoomOccupancy(activeDevicesPerRoom);
+  }
 });


### PR DESCRIPTION
Using realtime updates triggered a realtime message per row, since every row changed every five minutes we receive too many requests.

