### PR TITLE
Attempt to parse building number so fallback is used for invalid values

### DIFF
--- a/src/server/helpers/parse-message.test.ts
+++ b/src/server/helpers/parse-message.test.ts
@@ -29,7 +29,7 @@ test("Parse with common valid data", () => {
   })).toMatchInlineSnapshot(`
     {
       "access_point_name": "A-23-0-007",
-      "building_number": "23",
+      "building_number": 23,
       "device_count": 3,
       "floor": "BG",
       "location_hierarchy": "TUDelft > 23-CITG > BG",
@@ -54,7 +54,7 @@ test("Parse building number", () => {
     "from name with dashes"
   )
     .toContain({
-      "building_number": "24",
+      "building_number": 24,
     });
 
   expect(
@@ -70,7 +70,39 @@ test("Parse building number", () => {
     "from name with dots"
   )
     .toContain({
-      "building_number": "23",
+      "building_number": 23,
+    });
+
+  expect(
+    parseMessage({
+      timestamp: "1679400080000",
+      decodedValue: {
+        clientCount: 20,
+        locationHierarchy: "TUDelft > 34-3ME > 1e Verdieping",
+        mapLocation: "",
+        name: "nope-yes"
+      }
+    }),
+    "fallback with invalid name"
+  )
+    .toContain({
+      "building_number": 0,
+    });
+
+  expect(
+    parseMessage({
+      timestamp: "1679400080000",
+      decodedValue: {
+        clientCount: 20,
+        locationHierarchy: "TUDelft > 34-3ME > 1e Verdieping",
+        mapLocation: "nope.00.01.960 I2A08",
+        name: ""
+      }
+    }),
+    "fallback with invalid mapLocation"
+  )
+    .toContain({
+      "building_number": 0,
     });
 });
 

--- a/src/server/helpers/parse-message.ts
+++ b/src/server/helpers/parse-message.ts
@@ -6,8 +6,8 @@ export function parseMessage(
     "updated_at": new Date(Number(timestamp)).toISOString(),
     "access_point_name": decodedValue.name,
     "device_count": decodedValue.clientCount,
-    "building_number": decodedValue.name.split("-").at(1)
-      || decodedValue.mapLocation.split(".").at(0)
+    "building_number": Number(decodedValue.name.split("-").at(1))
+      || Number(decodedValue.mapLocation.split(".").at(0))
       || 0,
     "floor": decodedValue.locationHierarchy.split(">").at(-1).trim(),
     "room_id": decodedValue.mapLocation.split(" ").at(0),


### PR DESCRIPTION
Tested by temporarily routing kafka data to the preview deploy function, see the successful logs here: https://app.netlify.com/sites/spacefinder/functions/server?scope=deploypreview:184

Makes sure the extracted value is actually a number.