### PR TITLE
Feat/persistent zoom level on navigating

### DIFF
--- a/src/components/MapboxMap/MapboxMap.vue
+++ b/src/components/MapboxMap/MapboxMap.vue
@@ -59,6 +59,12 @@ function zoomOut() {
 function onResize() {
   mapStore.resizeMap();
 }
+function saveMapState() {
+  mapStore.saveMapState();
+}
+function restoreMapState() {
+  mapStore.restoreMapState();
+}
 
 /**
  * Mapbox renders insecure external links.
@@ -146,6 +152,8 @@ function initMap(accessToken: string) {
           "icon-allow-overlap": true,
         },
       });
+
+      restoreMapState();
       fixInsecureLinks();
       mapStore.setMap(map);
     });
@@ -159,6 +167,7 @@ function initMap(accessToken: string) {
       if (!properties.buildingSlug || !properties.spaceSlug) {
         return;
       }
+      saveMapState();
       router.push(
         $localePath("/buildings/:buildingSlug/spaces/:spaceSlug", {
           buildingSlug: properties.buildingSlug as string,

--- a/src/components/MapboxMap/MapboxMap.vue
+++ b/src/components/MapboxMap/MapboxMap.vue
@@ -176,6 +176,10 @@ function initMap(accessToken: string) {
       );
     }
   });
+
+  map.on("moveend", () => {
+    saveMapState();
+  });
 }
 </script>
 

--- a/src/pages/[locale]/buildings/index.vue
+++ b/src/pages/[locale]/buildings/index.vue
@@ -32,7 +32,7 @@ const title = computed(() => $t("buildingTitle"));
 useSpacefinderHead({ title });
 
 onMounted(() => {
-  mapStore.zoomToCampus();
+  mapStore.restoreMapState();
 });
 </script>
 

--- a/src/pages/[locale]/feedback.vue
+++ b/src/pages/[locale]/feedback.vue
@@ -18,6 +18,6 @@ const title = computed(() => $pageContent("feedbackPage.title"));
 useSpacefinderHead({ title });
 
 onMounted(() => {
-  mapStore.zoomToCampus();
+  mapStore.restoreMapState();
 });
 </script>

--- a/src/pages/[locale]/help.vue
+++ b/src/pages/[locale]/help.vue
@@ -20,6 +20,6 @@ const title = computed(() => $pageContent("infoPage.title"));
 useSpacefinderHead({ title });
 
 onMounted(() => {
-  mapStore.zoomToCampus();
+  mapStore.restoreMapState();
 });
 </script>

--- a/src/pages/[locale]/index.vue
+++ b/src/pages/[locale]/index.vue
@@ -28,6 +28,6 @@ useSpacefinderHead({
 });
 
 onMounted(() => {
-  mapStore.zoomToCampus();
+  mapStore.restoreMapState();
 });
 </script>


### PR DESCRIPTION
# Changes

<!-- example:
- Fix wrong color in button
- Add a new page
-->
- [add saveMapState and restoreMapState to persist map state](https://github.com/voorhoede/tudelft-spacefinder/commit/2bcc084fdd703ff4f771c41b719b2a36808fe811)
- [saveMapState on moveend to remember latest positions when moving the map](https://github.com/voorhoede/tudelft-spacefinder/commit/10bf0784adbb3aa856881d255058eb1e878b32ea)
- [use restored map state when navigating between pages instead of zoomed out view](https://github.com/voorhoede/tudelft-spacefinder/commit/bb23bc94e96debd60d6c9e6fdbd7a447f5ae1573)
# Associated issue

<!-- example:
Resolves https://trello.com/c/oYgBIyqt/2-document-architecture-change-in-decision-log
-->
Resolves https://trello.com/c/NAB8rsOQ/50-persistent-zoom-level-on-map-make-sure-all-markers-are-visible-on-object-detail-page

# How to test

<!-- example:
1. Open preview link: https://...
2. Click on *x*
3. Verify the button is red
-->
1. Open preview link
2. Click on a marker or building and navigate back. 
3. Check if the zoom level is still the same as before and the map position also

# Checklist

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->

- [x] I have performed a self-review of my own work
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have notified a reviewer
