### PR TITLE
Make sure the header information for both building card and building page are the same

### DIFF
--- a/src/components/BuildingCard/BuildingCard.vue
+++ b/src/components/BuildingCard/BuildingCard.vue
@@ -9,15 +9,16 @@
     />
 
     <div class="building-card__meta">
-      <ul class="flat-list building-card__seating">
-        <li>{{ totalSpaces }} {{ $t("locations") }}</li>
-        <li>{{ building.totalSeats }} {{ $t("seats") }}</li>
-      </ul>
+      <BuildingMeta
+        :spaces="totalSpaces"
+        :seats="building.totalSeats"
+      />
 
       <CardStatus
         :opening-hours="building.openingHours"
         class="building-card__status"
       />
+
       <div class="building-card__occupancy">
         <OccupancyIndicator
           :active-devices="building.activeDevices"
@@ -53,16 +54,6 @@ const totalSpaces = computed(() =>
   justify-content: space-between;
   align-items: center;
   font-size: var(--font-size-smaller);
-}
-
-.building-card__seating {
-  display: flex;
-}
-
-.building-card__seating li:not(:last-child):after {
-  content: "|";
-  display: inline-block;
-  margin: 0 var(--spacing-quarter);
 }
 
 .building-card__status {

--- a/src/components/BuildingHeader/BuildingHeader.vue
+++ b/src/components/BuildingHeader/BuildingHeader.vue
@@ -8,29 +8,16 @@
 
     <div class="building-header__meta">
       <div class="building-header__spaces">
-        <ul class="flat-list building-header__seating">
-          <li>
-            <SvgIcon
-              name="seat-icon"
-              class="building-header__seating-icon"
-            />
-            {{ building.totalSeats }}
-          </li>
-          <li>
-            <SvgIcon
-              name="door-icon"
-              class="building-header__seating-icon"
-            />
-            {{ totalSpaces }}
-          </li>
-        </ul>
-        <div class="building-header__occupancy">
-          <OccupancyIndicator
-            :active-devices="building.activeDevices"
-            :total-seats="building.totalSeats"
-            :occupancy="building.occupancy"
-          />
-        </div>
+        <BuildingMeta
+          :spaces="totalSpaces"
+          :seats="building.totalSeats"
+        />
+        <OccupancyIndicator
+          :active-devices="building.activeDevices"
+          :total-seats="building.totalSeats"
+          :occupancy="building.occupancy"
+          class="building-header__occupancy"
+        />
       </div>
 
       <CardStatus
@@ -61,14 +48,6 @@ const totalSpaces = computed(() =>
 <style>
 @import "../app-core/variables.css";
 
-.building-header__seating {
-  font-size: var(--font-size-smaller);
-  font-weight: bold;
-  display: flex;
-  align-items: flex-start;
-  gap: var(--spacing-default);
-}
-
 .building-header__meta {
   display: flex;
   justify-content: space-between;
@@ -80,18 +59,7 @@ const totalSpaces = computed(() =>
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: var(--spacing-half);
-}
-
-.building-header__seating li {
-  display: flex;
-  align-items: center;
-}
-
-.building-header__seating-icon {
-  margin-right: var(--spacing-half);
-  width: 15px;
-  height: 15px;
+  margin-bottom: var(--spacing-quarter);
 }
 
 .building-header__occupancy {

--- a/src/components/BuildingMeta/BuildingMeta.vue
+++ b/src/components/BuildingMeta/BuildingMeta.vue
@@ -1,0 +1,46 @@
+<template>
+  <ul class="flat-list building-meta">
+    <li class="building-meta__item">
+      <SvgIcon
+        name="seat-icon"
+        class="building-meta__seating-icon"
+      />
+      {{ props.seats }} {{ $t('seats') }}
+    </li>
+    <li class="building-meta__item">
+      <SvgIcon
+        name="door-icon"
+        class="building-meta__seating-icon"
+      />
+      {{ props.spaces }} {{ $t('spaces') }}
+    </li>
+  </ul>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{ seats: number, spaces: number }>();
+</script>
+
+<style>
+@import "../app-core/variables.css";
+
+.building-meta {
+  font-size: var(--font-size-smaller);
+  font-weight: bold;
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-default);
+}
+
+.building-meta__item {
+  display: flex;
+  align-items: center;
+  line-height: 1;
+}
+
+.building-meta__seating-icon {
+  margin-right: var(--spacing-half);
+  width: 15px;
+  height: 15px;
+}
+</style>

--- a/src/components/SpaceCard/SpaceCard.vue
+++ b/src/components/SpaceCard/SpaceCard.vue
@@ -45,7 +45,7 @@
       >
         <img
           v-if="space.image"
-          :src="space.image.url"
+          :src="`${space.image.url}?&fm=jpg&w=300&auto=quality&auto=format&auto=compress`"
           alt=""
         >
       </div>


### PR DESCRIPTION
# Changes

- Brings the styling of the building card and build detail page in line.
- Adds copy to make it more clear that the icons mean 'number of seats' and 'number of spaces'.

# Associated issue

Not available.

# How to test

1. Open preview link.
2. Navigate to the building overview page and see that number of seats and spaces is visible, including new copy.
3. Click on a building and check that the number of seats are visible using the same styling.

# Checklist

- [x] I have performed a self-review of my own work
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have notified a reviewer
