### PR TITLE
Don’t show opening hours in space card if the card is placed in a list

### DIFF
--- a/src/components/SpaceCard/SpaceCard.vue
+++ b/src/components/SpaceCard/SpaceCard.vue
@@ -30,9 +30,11 @@
       <CardStatus
         :opening-hours="space.openingHours"
         class="space-detail-card__open-status"
+        :class="{ 'space-detail-card__open-status--visible': !hideOpeningHours }"
       />
 
       <OpeningHours
+        v-if="!hideOpeningHours"
         :opening-hours-building="space.building.openingHours"
         :opening-hours-space="space.openingHours"
         :show-toggle-on-desktop="false"
@@ -75,7 +77,7 @@
 
 <script setup lang="ts">
 import type { Space } from "~/types/Space";
-defineProps<{ space: Space }>();
+defineProps<{ space: Space, hideOpeningHours: boolean }>();
 
 const root = ref(null as null | HTMLDivElement);
 
@@ -154,7 +156,11 @@ defineExpose({
 }
 
 .space-detail-card__open-status {
-  margin: var(--spacing-default) 0 -1.4rem 0;
+  margin-top: var(--spacing-half);
+}
+
+.space-detail-card__open-status--visible {
+  margin-bottom: -1.4rem;
 }
 
 @media (min-width: 700px) {

--- a/src/components/SpaceList/SpaceList.vue
+++ b/src/components/SpaceList/SpaceList.vue
@@ -27,7 +27,10 @@
           :to="$localePath('/buildings/:buildingSlug/spaces/:spaceSlug', { space })"
           class="space-list__link"
         >
-          <SpaceCard :space="space" />
+          <SpaceCard
+            :space="space"
+            :hide-opening-hours="true"
+          />
         </NuxtLink>
       </DynamicScrollerItem>
     </template>


### PR DESCRIPTION
# Changes

Fixes a bug where the opening hours are visible on the list view and building view. However, these opening hours should only be visible on the 

# Associated issue

Not applicable.

# How to test

1. Open preview link.
2. Go to the list view and to the building view; the opening hours for the coming week should not be visible.
3. Go to a space detail page; the opening hours should be visible.

# Checklist

- [x] I have performed a self-review of my own work
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have notified a reviewer
