### PR TITLE
Implement desktop design of space detail page

### DIFF
--- a/src/components/app-core/layout.css
+++ b/src/components/app-core/layout.css
@@ -81,6 +81,11 @@ body {
         width: calc(100% - var(--column-width-desktop));
     }
 
+    .default-layout__map--space-detail-page.default-layout__map {
+        margin-left: 0;
+        width: 100%;
+    }
+
     .mobile-only {
       display: none!important;
     }

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -22,7 +22,10 @@
     <main class="default-layout__main">
       <slot />
 
-      <MapboxMap class="default-layout__map" />
+      <MapboxMap
+        class="default-layout__map"
+        :class="{ 'default-layout__map--space-detail-page': isSpaceDetailPage}"
+      />
     </main>
 
     <AppNavigation
@@ -43,20 +46,43 @@
 </template>
 
 <script setup lang="ts">
+import { useMapStore } from "~/stores/map";
+
+const route = useRoute();
+const mapStore = useMapStore();
+
 const defaultLayout = ref<null | HTMLDivElement>(null);
 const openedMenu = ref<null | string>(null);
+
+let spaceSlug: string | string[];
+
+watch(route,
+  value => {
+    const previousSpaceSlug = spaceSlug
+    spaceSlug = value.params.spaceSlug
+
+    if (previousSpaceSlug !== spaceSlug) {
+      mapStore.resizeMap();
+    }
+  }
+);
+
+const isSpaceDetailPage = computed(() => route.params.spaceSlug !== undefined)
 
 const onResizeDebounce = useDebounceFn(onResize, 200);
 
 function openAppMenu() {
   openedMenu.value = "app-menu";
 }
+
 function openFilterMenu() {
   openedMenu.value = "filter-menu";
 }
+
 function closeMenu() {
   openedMenu.value = null;
 }
+
 function onResize() {
   const windowHeight = window.innerHeight * 0.01;
   defaultLayout.value!.style.setProperty(
@@ -92,6 +118,7 @@ useHead({
 .default-layout__notification-bar {
   display: none;
 }
+
 .old-ie .default-layout__notification-bar {
   display: block;
 }

--- a/src/pages/[locale]/buildings/[buildingSlug]/spaces/[spaceSlug].vue
+++ b/src/pages/[locale]/buildings/[buildingSlug]/spaces/[spaceSlug].vue
@@ -78,7 +78,7 @@ useSpacefinderHead(
 @media (min-width: 700px) {
   .space-detail__card {
     bottom: calc(var(--navigation-height-desktop) + var(--spacing-default));
-    width: 600px;
+    width: calc(var(--column-width-desktop) - var(--spacing-double));
   }
 }
 </style>

--- a/src/pages/[locale]/buildings/[buildingSlug]/spaces/[spaceSlug].vue
+++ b/src/pages/[locale]/buildings/[buildingSlug]/spaces/[spaceSlug].vue
@@ -1,5 +1,8 @@
 <template>
-  <section v-if="space">
+  <section
+    v-if="space"
+    class="space-detail"
+  >
     <BackButton
       :to="$localePath('/buildings/:buildingSlug', { space })"
       class="button--back"
@@ -79,6 +82,14 @@ useSpacefinderHead(
   .space-detail__card {
     bottom: calc(var(--navigation-height-desktop) + var(--spacing-default));
     width: calc(var(--column-width-desktop) - var(--spacing-double));
+  }
+
+  .space-detail .button--back {
+    left: var(--spacing-default);
+  }
+
+  .space-detail .button--route {
+    left: calc(5 * var(--spacing-default))
   }
 }
 </style>


### PR DESCRIPTION
# Changes

Implements the new design of the space detail page.

# Associated issue

Resolves https://trello.com/c/81Dtcfon/90-update-location-card-according-to-design

# How to test

1. Open preview link.
2. Navigate to a space.
3. On desktop: check if the space card is slightly less wide than the navigation bar.
4. On desktop: check if the map occupies the full width of the browser window.
5. On desktop: check if the back button and route button are positioned in the top left corner of the map.
6. On mobile the design should be the same as before.

# Checklist

- [x] I have performed a self-review of my own work
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have notified a reviewer
