### PR TITLE
Remove title from building page

### DIFF
--- a/src/components/SpaceList/SpaceList.vue
+++ b/src/components/SpaceList/SpaceList.vue
@@ -18,7 +18,9 @@
           v-if="index === 0"
           class="space-list__header"
         >
-          <h2>{{ $t("spacesTitle") }}</h2>
+          <h2 v-if="!hideTitle">
+            {{ $t("spacesTitle") }}
+          </h2>
           <p class="space-list__header-text">
             {{ $t("spacesSubTitle") }}
           </p>
@@ -49,7 +51,7 @@ import type { Space } from "~/types/Space";
 import { DynamicScroller, DynamicScrollerItem } from "vue-virtual-scroller";
 import "vue-virtual-scroller/dist/vue-virtual-scroller.css";
 
-defineProps<{ spaces: Space[] }>();
+defineProps<{ spaces: Space[]; hideTitle: boolean }>();
 </script>
 
 <style>

--- a/src/components/SpaceList/SpaceList.vue
+++ b/src/components/SpaceList/SpaceList.vue
@@ -49,7 +49,7 @@ import type { Space } from "~/types/Space";
 import { DynamicScroller, DynamicScrollerItem } from "vue-virtual-scroller";
 import "vue-virtual-scroller/dist/vue-virtual-scroller.css";
 
-defineProps<{ spaces: Space[]; showBuildingOccupancy: boolean }>();
+defineProps<{ spaces: Space[] }>();
 </script>
 
 <style>

--- a/src/components/app-core/layout.css
+++ b/src/components/app-core/layout.css
@@ -81,6 +81,11 @@ body {
         width: calc(100% - var(--column-width-desktop));
     }
 
+    .default-layout__map--space-detail-page.default-layout__map {
+        margin-left: 0;
+        width: 100%;
+    }
+
     .mobile-only {
       display: none!important;
     }

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -22,7 +22,10 @@
     <main class="default-layout__main">
       <slot />
 
-      <MapboxMap class="default-layout__map" />
+      <MapboxMap
+        class="default-layout__map"
+        :class="{ 'default-layout__map--space-detail-page': isSpaceDetailPage}"
+      />
     </main>
 
     <AppNavigation
@@ -43,20 +46,43 @@
 </template>
 
 <script setup lang="ts">
+import { useMapStore } from "~/stores/map";
+
+const route = useRoute();
+const mapStore = useMapStore();
+
 const defaultLayout = ref<null | HTMLDivElement>(null);
 const openedMenu = ref<null | string>(null);
+
+let spaceSlug: string | string[];
+
+watch(route,
+  value => {
+    const previousSpaceSlug = spaceSlug
+    spaceSlug = value.params.spaceSlug
+
+    if (previousSpaceSlug !== spaceSlug) {
+      mapStore.resizeMap();
+    }
+  }
+);
+
+const isSpaceDetailPage = computed(() => route.params.spaceSlug !== undefined)
 
 const onResizeDebounce = useDebounceFn(onResize, 200);
 
 function openAppMenu() {
   openedMenu.value = "app-menu";
 }
+
 function openFilterMenu() {
   openedMenu.value = "filter-menu";
 }
+
 function closeMenu() {
   openedMenu.value = null;
 }
+
 function onResize() {
   const windowHeight = window.innerHeight * 0.01;
   defaultLayout.value!.style.setProperty(
@@ -92,6 +118,7 @@ useHead({
 .default-layout__notification-bar {
   display: none;
 }
+
 .old-ie .default-layout__notification-bar {
   display: block;
 }

--- a/src/pages/[locale]/buildings/[buildingSlug]/index.vue
+++ b/src/pages/[locale]/buildings/[buildingSlug]/index.vue
@@ -13,7 +13,6 @@
       <SpaceList
         class="building-layout__spaces"
         :spaces="spaces"
-        :show-building-occupancy="false"
       />
     </div>
   </section>

--- a/src/pages/[locale]/buildings/[buildingSlug]/index.vue
+++ b/src/pages/[locale]/buildings/[buildingSlug]/index.vue
@@ -13,6 +13,7 @@
       <SpaceList
         class="building-layout__spaces"
         :spaces="spaces"
+        :hide-title="true"
       />
     </div>
   </section>

--- a/src/pages/[locale]/buildings/[buildingSlug]/spaces/[spaceSlug].vue
+++ b/src/pages/[locale]/buildings/[buildingSlug]/spaces/[spaceSlug].vue
@@ -78,7 +78,7 @@ useSpacefinderHead(
 @media (min-width: 700px) {
   .space-detail__card {
     bottom: calc(var(--navigation-height-desktop) + var(--spacing-default));
-    width: 600px;
+    width: calc(var(--column-width-desktop) - var(--spacing-double));
   }
 }
 </style>

--- a/src/pages/[locale]/buildings/[buildingSlug]/spaces/[spaceSlug].vue
+++ b/src/pages/[locale]/buildings/[buildingSlug]/spaces/[spaceSlug].vue
@@ -1,5 +1,8 @@
 <template>
-  <section v-if="space">
+  <section
+    v-if="space"
+    class="space-detail"
+  >
     <BackButton
       :to="$localePath('/buildings/:buildingSlug', { space })"
       class="button--back"
@@ -79,6 +82,14 @@ useSpacefinderHead(
   .space-detail__card {
     bottom: calc(var(--navigation-height-desktop) + var(--spacing-default));
     width: calc(var(--column-width-desktop) - var(--spacing-double));
+  }
+
+  .space-detail .button--back {
+    left: var(--spacing-default);
+  }
+
+  .space-detail .button--route {
+    left: calc(5 * var(--spacing-default))
   }
 }
 </style>

--- a/src/pages/[locale]/index.vue
+++ b/src/pages/[locale]/index.vue
@@ -6,10 +6,7 @@
     <h2 class="a11y-sr-only">
       {{ allSpacesTitle }}
     </h2>
-    <SpaceList
-      :spaces="spacesStore.filteredSpaces"
-      :show-building-occupancy="true"
-    />
+    <SpaceList :spaces="spacesStore.filteredSpaces" />
   </section>
 </template>
 

--- a/src/pages/[locale]/spaces.vue
+++ b/src/pages/[locale]/spaces.vue
@@ -3,10 +3,7 @@
     <h2 class="a11y-sr-only">
       {{ allSpacesTitle }}
     </h2>
-    <SpaceList
-      :spaces="spacesStore.filteredSpaces"
-      :show-building-occupancy="true"
-    />
+    <SpaceList :spaces="spacesStore.filteredSpaces" />
   </section>
 </template>
 


### PR DESCRIPTION
# Changes

Make title of the `<SpaceList>` component optional.

# Associated issue

Resolves https://trello.com/c/UbezKyxZ/102-remove-title-spaces-on-campus-from-object-detail-page

# How to test

1. Open preview link.
2. Go to the spaces view and see that the title "Spaces on the campus" is still visible.
3. Go to a building view and see that the title is not visible.

# Checklist

- [x] I have performed a self-review of my own work
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have notified a reviewer
