### PR TITLE
Add description to available seats

### DIFF
--- a/src/components/BuildingMeta/BuildingMeta.vue
+++ b/src/components/BuildingMeta/BuildingMeta.vue
@@ -1,11 +1,22 @@
 <template>
   <ul class="flat-list building-meta">
     <li class="building-meta__item">
-      <SvgIcon
-        name="seat-icon"
-        class="building-meta__seating-icon"
-      />
-      {{ props.seats }} {{ $t('seats') }}
+      <Tooltip
+        :delay="0"
+        :overflow-padding="4"
+        :instant-move="true"
+      >
+        <div class="building-meta__item-content">
+          <SvgIcon
+            name="seat-icon"
+            class="building-meta__seating-icon"
+          />
+          {{ props.seats }} {{ $t('seats') }}
+        </div>
+        <template #popper>
+          {{ $t('capacity') }}: {{ props.seats }} {{ $t('seats') }}
+        </template>
+      </Tooltip>
     </li>
     <li class="building-meta__item">
       <SvgIcon
@@ -18,6 +29,7 @@
 </template>
 
 <script setup lang="ts">
+import { Tooltip } from "floating-vue";
 const props = defineProps<{ seats: number, spaces: number }>();
 </script>
 
@@ -32,7 +44,8 @@ const props = defineProps<{ seats: number, spaces: number }>();
   gap: var(--spacing-default);
 }
 
-.building-meta__item {
+.building-meta__item,
+.building-meta__item-content {
   display: flex;
   align-items: center;
   line-height: 1;

--- a/src/components/SpaceCard/SpaceCard.vue
+++ b/src/components/SpaceCard/SpaceCard.vue
@@ -10,11 +10,22 @@
         </h2>
 
         <div class="space-detail-card__seating">
-          <SvgIcon
-            name="seat-icon"
-            class="space-detail-card__seating-icon"
-          />
-          {{ space.seats }}
+          <Tooltip
+            :delay="0"
+            :overflow-padding="4"
+            :instant-move="true"
+          >
+            <div>
+              <SvgIcon
+                name="seat-icon"
+                class="space-detail-card__seating-icon"
+              />
+              {{ space.seats }}
+            </div>
+            <template #popper>
+              {{ $t('capacity') }}: {{ space.seats }} {{ $t('seats') }}
+            </template>
+          </Tooltip>
         </div>
       </div>
       
@@ -76,6 +87,7 @@
 </template>
 
 <script setup lang="ts">
+import { Tooltip } from "floating-vue";
 import type { Space } from "~/types/Space";
 defineProps<{ space: Space, hideOpeningHours: boolean }>();
 

--- a/src/data/en/messages.json
+++ b/src/data/en/messages.json
@@ -21,6 +21,7 @@
   "buildings.58": "AS South",
   "buildings.62": "AE",
   "buildings.66": "Fellow",
+  "capacity": "Total capacity",
   "clearFilters": "clear filters",
   "close": "close",
   "closed": "closed",

--- a/src/data/nl/messages.json
+++ b/src/data/nl/messages.json
@@ -21,6 +21,7 @@
   "buildings.58": "TNW Zuid",
   "buildings.62": "LR",
   "buildings.66": "Fellow",
+  "capacity": "Totale capaciteit",
   "clearFilters": "wis filters",
   "close": "sluit",
   "closed": "gesloten",


### PR DESCRIPTION
# Changes

Adds tooltips to the number of spaces icon to inform the user of what this value exactly indicates.

# Associated issue

Resolves: https://trello.com/c/mNq8T4CU/96-change-copy-zitplaatsen-beschikbaar

# How to test

1. Open preview link.
2. Go to a building detail view and hover over the number of seats available; the description should be visible in the tooltip.
3. Also hover over the number of spaces of a space card in the building detail view; the description should be visible in the tooltip.
4. Go to a space view and hover over the number of seats available; the description should be visible in the tooltip.
5. This should also work on mobile.

# Checklist

- [x] I have performed a self-review of my own work
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have notified a reviewer
