### PR TITLE
Feat/rename monitor to presentation screen

### DIFF
--- a/src/data/en/messages.json
+++ b/src/data/en/messages.json
@@ -61,7 +61,7 @@
   "quietness.quiet": "quiet",
   "open": "open",
   "openingHours": "opening hours",
-  "presentationScreen": "monitor",
+  "presentationScreen": "presentation screen",
   "route": "navigate to space",
   "routes.buildings": "buildings",
   "routes.feedback": "feedback",

--- a/src/data/nl/messages.json
+++ b/src/data/nl/messages.json
@@ -61,7 +61,7 @@
   "quietness.quiet": "rustig",
   "open": "open",
   "openingHours": "openingstijden",
-  "presentationScreen": "monitor",
+  "presentationScreen": "presentatiescherm",
   "route": "navigeer naar ruimte",
   "routes.buildings": "gebouwen",
   "routes.feedback": "feedback",


### PR DESCRIPTION
# Changes

<!-- example:
- Fix wrong color in button
- Add a new page
-->
- [feat: rename monitor filter to presentation screen](https://github.com/voorhoede/tudelft-spacefinder/commit/67eeea6fd5cb00c17b64696fd347b75defe491ad)
# Associated issue

<!-- example:
Resolves https://trello.com/c/oYgBIyqt/2-document-architecture-change-in-decision-log
-->
Resolves: https://trello.com/c/fLAPAif0/108-change-filter-name-monitor-to-presentatiescherm

# How to test

<!-- example:
1. Open preview link: https://...
2. Click on *x*
3. Verify the button is red
-->
1. Open preview link
2. Click on the filters and see that monitor is renamed to presentation screen

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->

- [x] I have performed a self-review of my own work
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have notified a reviewer
