### PR TITLE
Fix/unshift filters by adding null fields

### DIFF
--- a/scripts/data/csv/config.ts
+++ b/scripts/data/csv/config.ts
@@ -36,7 +36,10 @@ export default {
     null,
     "daylit",
     "powerOutlets",
+    null, // this was the ethernet field in the csv which is permanently removed as filter
+    null, // this was the stationaryPC field in the csv which is permanently removed as filter and will be replaced for dockingstations
     "whiteBoard",
+    null, // this was the smartBoard field in the csv which is permanently removed as filter 
     "presentationScreen",
     "nearCoffeeMachine",
     "nearPrinter",


### PR DESCRIPTION

# Changes

<!-- example:
- Fix wrong color in button
- Add a new page
-->
[fix: previously we removed the filters here which caused shifted rows…](https://github.com/voorhoede/tudelft-spacefinder/commit/a73d59aeb6131d7eceb33f04464b4bfc515536a7)

# Associated issue

<!-- example:
Resolves https://trello.com/c/oYgBIyqt/2-document-architecture-change-in-decision-log
-->
Resolves: https://trello.com/c/J9uDZieN/112-fix-printer-filters-its-showing-10-now

# How to test

<!-- example:
1. Open preview link: https://...
2. Click on *x*
3. Verify the button is red
-->
1. Open preview link
2. Check printer filters it shows a lot more results than before

# Checklist

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->

- [x] I have performed a self-review of my own work
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have notified a reviewer
