### PR TITLE
Feat/names of noise level

### DIFF
--- a/src/data/en/messages.json
+++ b/src/data/en/messages.json
@@ -58,7 +58,7 @@
   "quietness": "Noise level",
   "quietness.silent": "silent",
   "quietness.noisy": "noisy",
-  "quietness.quiet": "quiet",
+  "quietness.quiet": "fairly quiet",
   "open": "open",
   "openingHours": "opening hours",
   "presentationScreen": "presentation screen",

--- a/src/data/nl/messages.json
+++ b/src/data/nl/messages.json
@@ -58,7 +58,7 @@
   "quietness": "Geluidsniveau",
   "quietness.silent": "stil",
   "quietness.noisy": "rumoerig",
-  "quietness.quiet": "rustig",
+  "quietness.quiet": "redelijk stil",
   "open": "open",
   "openingHours": "openingstijden",
   "presentationScreen": "presentatiescherm",


### PR DESCRIPTION
# Changes

<!-- example:
- Fix wrong color in button
- Add a new page
-->
[fix: add redelijk stil as noise level](https://github.com/voorhoede/tudelft-spacefinder/commit/c1e29950ea5f389e4478b85d49bd206363e2809e)

# Associated issue

<!-- example:
Resolves https://trello.com/c/oYgBIyqt/2-document-architecture-change-in-decision-log
-->
Resolves: https://trello.com/c/zSc8a0EQ/87-names-of-icons-geluidsniveau-and-drukte

# How to test

<!-- example:
1. Open preview link: https://...
2. Click on *x*
3. Verify the button is red
-->
1. Open preview link
2. rustig changed to redelijk stil in the filter menu

# Checklist

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->

- [x] I have performed a self-review of my own work
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have notified a reviewer
