### PR TITLE
Feat/buildings as default route

### DIFF
--- a/src/pages/[locale]/index.vue
+++ b/src/pages/[locale]/index.vue
@@ -1,30 +1,55 @@
 <template>
   <section
     v-if="!$isMobile.value"
-    class="default-layout__info"
+    class="default-layout__info building-overview"
   >
     <h2 class="a11y-sr-only">
-      {{ allSpacesTitle }}
+      {{ title }}
     </h2>
-    <SpaceList :spaces="spacesStore.filteredSpaces" />
+
+    <BuildingCard
+      v-for="building in buildingsOrdered"
+      :key="building.number"
+      :building="building"
+    />
   </section>
 </template>
 
 <script setup lang="ts">
 import { useSpacesStore } from "~/stores/spaces";
 import { useMapStore } from "~/stores/map";
-const { $t } = useNuxtApp();
 const spacesStore = useSpacesStore();
+
 const mapStore = useMapStore();
+const { $t } = useNuxtApp();
 
-const allSpacesTitle = computed(() => $t("allSpaces"));
+const buildingsOrdered = computed(() =>
+  [...spacesStore.buildings].sort((a, b) => a.name.localeCompare(b.name))
+);
 
-useSpacefinderHead({
-  title: computed(() => $t("spacesTitle")),
-  description: allSpacesTitle,
-});
+const title = computed(() => $t("buildingTitle"));
+
+useSpacefinderHead({ title });
 
 onMounted(() => {
   mapStore.restoreMapState();
 });
 </script>
+
+<style>
+.building-overview {
+  padding: var(--spacing-default);
+  height: calc(100% - var(--navigation-height-mobile));
+  -webkit-overflow-scrolling: touch;
+}
+
+@media (min-width: 700px) {
+  .building-overview {
+    height: calc(100% - var(--navigation-height-desktop));
+  }
+}
+
+.building-overview .building-card:not(:last-child) {
+  margin-bottom: var(--spacing-default);
+}
+</style>


### PR DESCRIPTION
# Changes

<!-- example:
- Fix wrong color in button
- Add a new page
-->
[feat: add building as default "route"](https://github.com/voorhoede/tudelft-spacefinder/commit/c581004abd5df21d325639671cf350aaa5c81e0d)

# Associated issue

<!-- example:
Resolves https://trello.com/c/oYgBIyqt/2-document-architecture-change-in-decision-log
-->
Resolves: https://trello.com/c/85bHy03c/110-make-building-view-default-view-on-desktop

# How to test

<!-- example:
1. Open preview link: https://...
2. Click on *x*
3. Verify the button is red
-->
1. Open preview link
2. Check if buildings is now the default homepage for mobile and desktop

# Checklist

<!-- Please strike through and check off all items that do not apply (rather than removing them) -->

- [x] I have performed a self-review of my own work
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have notified a reviewer
