### PR TITLE
Add filter for number of seats

### DIFF
--- a/schema/room.json
+++ b/schema/room.json
@@ -76,7 +76,8 @@
         "presentationScreen": { "type": "boolean" },
         "nearCoffeeMachine": { "type": "boolean" },
         "nearPrinter": { "type": "boolean" },
-        "nearBathroom": { "type": "boolean" }
+        "nearBathroom": { "type": "boolean" },
+        "numberOfSeats": { "type": "number" }
       },
       "additionalProperties": false,
       "required":[

--- a/schema/space.json
+++ b/schema/space.json
@@ -80,7 +80,8 @@
         "presentationScreen": { "type": "boolean" },
         "nearCoffeeMachine": { "type": "boolean" },
         "nearPrinter": { "type": "boolean" },
-        "nearBathroom": { "type": "boolean" }
+        "nearBathroom": { "type": "boolean" },
+        "numberOfSeats": { "type": "number" }
       },
       "additionalProperties": false,
       "required":[

--- a/src/components/AppNavigation/AppNavigation.vue
+++ b/src/components/AppNavigation/AppNavigation.vue
@@ -141,6 +141,7 @@ watch(
   background: var(--background-color);
   border: none;
   border-radius: 2rem;
+  cursor: pointer;
 }
 
 .app-menu__filter-button-icon {

--- a/src/components/FilterMenu/FilterMenu.vue
+++ b/src/components/FilterMenu/FilterMenu.vue
@@ -41,6 +41,17 @@
 
         <fieldset class="filter-menu__filter-group">
           <legend class="h3">
+            {{ $t("numberOfSeats") }}
+          </legend>
+
+          <FilterMenuItemRange
+            name="numberOfSeats"
+            :label="$t('seats')"
+          />
+        </fieldset>
+
+        <fieldset class="filter-menu__filter-group">
+          <legend class="h3">
             {{ $t("computerFacilities") }}
           </legend>
           <FilterMenuItem name="powerOutlets" />

--- a/src/components/FilterMenu/FilterMenuItemRange.vue
+++ b/src/components/FilterMenu/FilterMenuItemRange.vue
@@ -8,15 +8,15 @@
 
     <input
       :id="inputId"
-      v-model="spacesStore.filters[name]"
+      v-model.number="spacesStore.filters[name]"
       type="range"
-      min="1"
+      min="0"
       :max="maxValue"
       class="filter-menu-item-range__input"
     >
 
     <label :for="inputId">
-      {{ labelValue }}
+      {{ labelValue ?? $t('noSeatsFilterLabel') }}
       <span class="a11y-sr-only">
         {{ label ?? $t(i18nKey) }}
       </span>
@@ -60,9 +60,13 @@ const i18nKey = computed(() =>
 const iconName = computed(() => `facility-${i18nKey.value}-icon`);
 
 const labelValue = computed(() => {
-  return spacesStore.filters[props.name]
-    ? spacesStore.filters[props.name] < 10 ?  spacesStore.filters[props.name] : `${spacesStore.filters[props.name]}+`
-    : '1';
+  if (spacesStore.filters[props.name] == 0) {
+    return null
+  } else if (spacesStore.filters[props.name] == 10) {
+    return `${spacesStore.filters[props.name]}+`
+  } else {
+    return spacesStore.filters[props.name]
+  }
 });
 
 const spacesStore = useSpacesStore();

--- a/src/components/FilterMenu/FilterMenuItemRange.vue
+++ b/src/components/FilterMenu/FilterMenuItemRange.vue
@@ -1,0 +1,130 @@
+<template>
+  <div class="filter-menu-item-range">
+    <SvgIcon
+      v-if="showIcon"
+      :name="iconName"
+      class="filter-menu-item-range__icon"
+    />
+
+    <input
+      :id="inputId"
+      v-model="spacesStore.filters[name]"
+      type="range"
+      min="1"
+      :max="maxValue"
+      class="filter-menu-item-range__input"
+    >
+
+    <label :for="inputId">
+      {{ labelValue }}
+      <span class="a11y-sr-only">
+        {{ label ?? $t(i18nKey) }}
+      </span>
+    </label>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useSpacesStore } from "~/stores/spaces";
+import type { Filters } from "~/types/Filters";
+
+const props = withDefaults(
+  defineProps<{
+    /** The name of the property to bind to in the global filter object */
+    name: keyof Filters;
+    /** Used to determine the i18n key for the labe and the icon name. If not specified, name is used */
+    displayKey?: string;
+    /** Allows to override the label text */
+    label?: string;
+    /** False if you do not want to display an icon */
+    showIcon?: boolean;
+    /** The maximum input value of the range slider */
+    maxValue?: number;
+  }>(),
+  {
+    displayKey: undefined,
+    label: undefined,
+    showIcon: true,
+    maxValue: 10,
+  }
+);
+
+const inputId = computed(() =>
+  `filter-item-${props.name}`
+);
+
+const i18nKey = computed(() =>
+  [props.displayKey ?? props.name].filter(Boolean).join(".")
+);
+
+const iconName = computed(() => `facility-${i18nKey.value}-icon`);
+
+const labelValue = computed(() => {
+  return spacesStore.filters[props.name]
+    ? spacesStore.filters[props.name] < 10 ?  spacesStore.filters[props.name] : `${spacesStore.filters[props.name]}+`
+    : '1';
+});
+
+const spacesStore = useSpacesStore();
+</script>
+
+<style>
+@import "../app-core/variables.css";
+
+.filter-menu-item-range {
+  display: inline-flex;
+  align-items: center;
+  margin: 0 var(--spacing-quarter) var(--spacing-half) 0;
+  padding-right: var(--spacing-three-quarter);
+  padding-left: var(--spacing-default);
+  font-size: var(--font-size-smaller);
+  background: var(--highlight-color);
+  border: 1px solid transparent;
+  border-radius: 1rem;
+  line-height: 2rem;
+}
+
+.filter-menu-item-range__icon {
+  margin-left: var(--spacing-half-negative);
+  margin-bottom: -11px;
+  width: 25px;
+  height: 25px;
+}
+
+.filter-menu-item-range__input {
+  appearance: none;
+  margin-right: var(--spacing-half);
+  width: 125px;
+  cursor: pointer;
+  background: transparent;
+}
+
+.filter-menu-item-range__input::-webkit-slider-runnable-track {
+  background: var(--text-color);
+  height: 2px;
+  border-radius: 2px;
+}
+
+.filter-menu-item-range__input::-moz-range-track {
+  background: var(--text-color);
+  height: 2px;
+  border-radius: 2px;
+}
+
+.filter-menu-item-range__input::-webkit-slider-thumb {
+  appearance: none;
+  margin-top: -7px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background-color: var(--brand-primary-color);
+}
+
+.filter-menu-item-range__input::-moz-range-thumb {
+  appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background-color: var(--brand-primary-color);
+}
+</style>

--- a/src/components/FilterMenu/FilterMenuItemRange.vue
+++ b/src/components/FilterMenu/FilterMenuItemRange.vue
@@ -60,9 +60,12 @@ const i18nKey = computed(() =>
 const iconName = computed(() => `facility-${i18nKey.value}-icon`);
 
 const labelValue = computed(() => {
-  if (spacesStore.filters[props.name] == 0) {
+  const DEFAULT_VALUE = 0;
+  const MAX_VALUE = 10;
+
+  if (spacesStore.filters[props.name] == DEFAULT_VALUE) {
     return null
-  } else if (spacesStore.filters[props.name] == 10) {
+  } else if (spacesStore.filters[props.name] == MAX_VALUE) {
     return `${spacesStore.filters[props.name]}+`
   } else {
     return spacesStore.filters[props.name]

--- a/src/components/SpriteMap/SpriteMap.vue
+++ b/src/components/SpriteMap/SpriteMap.vue
@@ -109,6 +109,16 @@
     </symbol>
 
     <symbol
+      id="facility-numberOfSeats-icon"
+      viewBox="0 0 20 20"
+    >
+      <path
+        d="M1.1 8.3V10h1.7V8.3h5.5V10H10V6.7H1.1v1.6zM9.4 4h1.7v1.7H9.4V3.9zM0 3.9h1.7v1.7H0V3.9zm8.3 1.7H2.8V1c0-.6.5-1.1 1-1.1h3.4c.6 0 1.1.5 1.1 1.1v4.5z"
+        fill-rule="nonzero"
+      />
+    </symbol>
+
+    <symbol
       id="facility-powerOutlets-icon"
       viewBox="0 0 20 20"
     >

--- a/src/data/en/messages.json
+++ b/src/data/en/messages.json
@@ -54,6 +54,7 @@
   "nearCoffeeMachine": "coffee corner",
   "nearPrinter": "printer",
   "noFilterResults": "There are no locations found",
+  "noSeatsFilterLabel": "all",
   "numberOfSeats": "Number of seats",
   "powerOutlets": "sockets",
   "quietness": "Noise level",

--- a/src/data/en/messages.json
+++ b/src/data/en/messages.json
@@ -54,6 +54,7 @@
   "nearCoffeeMachine": "coffee corner",
   "nearPrinter": "printer",
   "noFilterResults": "There are no locations found",
+  "numberOfSeats": "Number of seats",
   "powerOutlets": "sockets",
   "quietness": "Noise level",
   "quietness.silent": "silent",

--- a/src/data/nl/messages.json
+++ b/src/data/nl/messages.json
@@ -54,6 +54,7 @@
   "nearCoffeeMachine": "coffee corner",
   "nearPrinter": "printer",
   "noFilterResults": "Er zijn geen locaties gevonden",
+  "noSeatsFilterLabel": "alles",
   "numberOfSeats": "Aantal zitplaatsen",
   "powerOutlets": "stopcontact",
   "quietness": "Geluidsniveau",

--- a/src/data/nl/messages.json
+++ b/src/data/nl/messages.json
@@ -54,6 +54,7 @@
   "nearCoffeeMachine": "coffee corner",
   "nearPrinter": "printer",
   "noFilterResults": "Er zijn geen locaties gevonden",
+  "numberOfSeats": "Aantal zitplaatsen",
   "powerOutlets": "stopcontact",
   "quietness": "Geluidsniveau",
   "quietness.silent": "stil",

--- a/src/lib/filter-spaces.ts
+++ b/src/lib/filter-spaces.ts
@@ -62,6 +62,13 @@ function filterSpace(
         space.building.occupancy &&
         filters.buildingOccupancy.includes(space.building.occupancy)
       );
+    if (activeFilterKey == "numberOfSeats") {
+      if (filters.numberOfSeats < 10) {
+        return space.seats == filters.numberOfSeats
+      } else {
+        return space.seats >= filters.numberOfSeats
+      }
+    }
     return space.facilities[activeFilterKey];
   });
 }

--- a/src/stores/spaces.ts
+++ b/src/stores/spaces.ts
@@ -53,7 +53,7 @@ export const useSpacesStore = defineStore("spaces", () => {
     nearBathroom: false,
     nearCoffeeMachine: false,
     nearPrinter: false,
-    numberOfSeats: 10,
+    numberOfSeats: 0,
     powerOutlets: false,
     presentationScreen: false,
     quietness: [],
@@ -242,8 +242,10 @@ export const useSpacesStore = defineStore("spaces", () => {
 
   const numberOfSelectedFilters = computed(
     () => {
-      return Object.values(filters.value).reduce((acc, item) => {
-        return acc + (item === true ? 1 : item.length > 0 ? item.length : 0)
+      // Filter out numberOfSeats when that value is 0, i.e. not selected
+      const selectedFilters = Object.values(filters.value).filter(item => item !== 0)
+      return selectedFilters.reduce((acc, item) => {
+        return acc + (item === true || item > 0 ? 1 : item.length > 0 ? item.length : 0)
       }, 0)
     }
   );

--- a/src/stores/spaces.ts
+++ b/src/stores/spaces.ts
@@ -53,6 +53,7 @@ export const useSpacesStore = defineStore("spaces", () => {
     nearBathroom: false,
     nearCoffeeMachine: false,
     nearPrinter: false,
+    numberOfSeats: 10,
     powerOutlets: false,
     presentationScreen: false,
     quietness: [],

--- a/src/types/Filters.ts
+++ b/src/types/Filters.ts
@@ -14,10 +14,19 @@ export const FACILITIES = [
   "nearCoffeeMachine",
   "nearPrinter",
   "nearBathroom",
+  "numberOfSeats",
 ] as const;
 
 export type Facilities = {
-  [P in typeof FACILITIES[number]]: boolean;
+  "adjustableChairs": boolean,
+  "daylit": boolean,
+  "powerOutlets": boolean,
+  "whiteBoard": boolean,
+  "presentationScreen": boolean,
+  "nearCoffeeMachine": boolean,
+  "nearPrinter": boolean,
+  "nearBathroom": boolean,
+  "numberOfSeats": number,
 };
 
 export type SpaceFeatures = Facilities & {

--- a/src/types/Filters.ts
+++ b/src/types/Filters.ts
@@ -5,7 +5,7 @@ export interface Filters extends Facilities {
   showOpenLocations: boolean;
 }
 
-export const FACILITIES = [
+export const BOOLEAN_FACILITIES = [
   "adjustableChairs",
   "daylit",
   "powerOutlets",
@@ -14,19 +14,16 @@ export const FACILITIES = [
   "nearCoffeeMachine",
   "nearPrinter",
   "nearBathroom",
+] as const;
+
+export const NUMBER_FACILITIES = [
   "numberOfSeats",
 ] as const;
 
 export type Facilities = {
-  "adjustableChairs": boolean,
-  "daylit": boolean,
-  "powerOutlets": boolean,
-  "whiteBoard": boolean,
-  "presentationScreen": boolean,
-  "nearCoffeeMachine": boolean,
-  "nearPrinter": boolean,
-  "nearBathroom": boolean,
-  "numberOfSeats": number,
+  [P in typeof BOOLEAN_FACILITIES[number]]: boolean;
+} & {
+  [P in typeof NUMBER_FACILITIES[number]]: number;
 };
 
 export type SpaceFeatures = Facilities & {


### PR DESCRIPTION
# Changes

Adds an item in the filter menu with which the user can filter on number of seats. The default is that no filtering is applied. When sliding the input, a user can filter on a specific number of seats. The maximum input is 10 seats or higher.

# Associated issue

Resolves https://trello.com/c/RYTUsSZt/52-determine-which-icons-and-filters-are-still-relevant

# How to test

1. Open preview link.
2. Go to the spaces view.
3. Filter on number of seats. You can easily see in the spaces list if te filter is working.

# Checklist

- [x] I have performed a self-review of my own work
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have notified a reviewer
