### PR TITLE
Make sure the language of the page is described in the html tag

### DIFF
--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -47,6 +47,7 @@ import { useMapStore } from "~/stores/map";
 
 const route = useRoute();
 const mapStore = useMapStore();
+const { $locale } = useNuxtApp();
 
 const defaultLayout = ref<null | HTMLDivElement>(null);
 const openedMenu = ref<null | string>(null);
@@ -108,6 +109,7 @@ useHead({
       `,
     },
   ],
+  htmlAttrs: { lang: $locale }
 });
 </script>
 


### PR DESCRIPTION
# Changes

Adds the `lang` attribute to the html tag to indicate the language of the page.

# Associated issue

Partly resolves https://trello.com/c/C9CYUm8O/63-accessibility-improvements-for-spacefinder-app-and-map.

# How to test

1. Open preview link.
2. Make sure the `lang` attribute is visible on the html tag on every page.

# Checklist

- [x] I have performed a self-review of my own work
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have notified a reviewer
