### PR TITLE
Improve heading structure for app

### DIFF
--- a/src/components/BuildingCard/BuildingCard.vue
+++ b/src/components/BuildingCard/BuildingCard.vue
@@ -5,6 +5,7 @@
   >
     <BuildingImage
       :building="building"
+      :is-header="isHeader"
       class="building-card__image"
     />
 
@@ -32,7 +33,7 @@
 
 <script setup lang="ts">
 import type { Building } from "~/types/Building";
-const props = defineProps<{ building: Building }>();
+const props = defineProps<{ building: Building, isHeader?: boolean }>();
 const runtimeConfig = useRuntimeConfig();
 const totalSpaces = computed(() =>
   runtimeConfig.public.spacesMode == "rooms"

--- a/src/components/BuildingHeader/BuildingHeader.vue
+++ b/src/components/BuildingHeader/BuildingHeader.vue
@@ -2,10 +2,6 @@
   <div class="building-header">
     <BuildingImage :building="building" />
 
-    <h3 class="a11y-sr-only">
-      {{ $t("seating") }}
-    </h3>
-
     <div class="building-header__meta">
       <div class="building-header__spaces">
         <BuildingMeta

--- a/src/components/BuildingImage/BuildingImage.vue
+++ b/src/components/BuildingImage/BuildingImage.vue
@@ -1,6 +1,16 @@
 <template>
   <div class="building-image">
+    <h3
+      v-if="isHeader"
+      class="building-image__title"
+      :style="`background-image: url('${building.image.url}?&fm=jpg&w=700&h=150&fit=crop&auto=quality&auto=format&auto=compress');`"
+    >
+      <span class="building-image__name">
+        {{ building.name }} ({{ building.abbreviation }})
+      </span>
+    </h3>
     <h2
+      v-else
       class="building-image__title"
       :style="`background-image: url('${building.image.url}?&fm=jpg&w=700&h=150&fit=crop&auto=quality&auto=format&auto=compress');`"
     >
@@ -14,7 +24,7 @@
 <script setup lang="ts">
 import type { Building } from "~/types/Building";
 
-defineProps<{ building: Building }>();
+defineProps<{ building: Building, isHeader?: boolean }>();
 </script>
 
 <style>

--- a/src/components/BuildingImage/BuildingImage.vue
+++ b/src/components/BuildingImage/BuildingImage.vue
@@ -1,23 +1,14 @@
 <template>
   <div class="building-image">
-    <h3
-      v-if="isHeader"
+    <component
+      :is="isHeader ? 'h3' : 'h2'"
       class="building-image__title"
       :style="`background-image: url('${building.image.url}?&fm=jpg&w=700&h=150&fit=crop&auto=quality&auto=format&auto=compress');`"
     >
       <span class="building-image__name">
         {{ building.name }} ({{ building.abbreviation }})
       </span>
-    </h3>
-    <h2
-      v-else
-      class="building-image__title"
-      :style="`background-image: url('${building.image.url}?&fm=jpg&w=700&h=150&fit=crop&auto=quality&auto=format&auto=compress');`"
-    >
-      <span class="building-image__name">
-        {{ building.name }} ({{ building.abbreviation }})
-      </span>
-    </h2>
+    </component>
   </div>
 </template>
 

--- a/src/components/SpaceCard/SpaceCard.vue
+++ b/src/components/SpaceCard/SpaceCard.vue
@@ -40,9 +40,18 @@
     >
       <div class="space-card__left-column">
         <div class="space-card__header">
-          <h2 class="space-card__title">
+          <h2
+            v-if="isHeader"
+            class="space-card__title"
+          >
             {{ space.name }}
           </h2>
+          <h3
+            v-else
+            class="space-card__title"
+          >
+            {{ space.name }}
+          </h3>
 
           <div class="space-card__seating">
             <Tooltip
@@ -132,6 +141,7 @@ import type { AssociatedSpace } from "~/stores/spaces";
 const props = defineProps<{
   space: Space,
   hideOpeningHours?: boolean,
+  isHeader?: boolean,
   associatedSpaces?: AssociatedSpace[]
 }>();
 

--- a/src/components/SpaceCard/SpaceCard.vue
+++ b/src/components/SpaceCard/SpaceCard.vue
@@ -40,18 +40,13 @@
     >
       <div class="space-card__left-column">
         <div class="space-card__header">
-          <h2
+          <component
             v-if="isHeader"
+            :is="isHeader ? 'h2' : 'h3'"
             class="space-card__title"
           >
             {{ space.name }}
-          </h2>
-          <h3
-            v-else
-            class="space-card__title"
-          >
-            {{ space.name }}
-          </h3>
+          </component>
 
           <div class="space-card__seating">
             <Tooltip

--- a/src/pages/[locale]/buildings/[buildingSlug]/spaces/[spaceSlug].vue
+++ b/src/pages/[locale]/buildings/[buildingSlug]/spaces/[spaceSlug].vue
@@ -19,6 +19,7 @@
       :space="space"
       :associated-spaces="associatedSpaces"
       class="space-detail__card"
+      :is-header="true"
     />
   </section>
 </template>

--- a/src/pages/[locale]/buildings/[buildingSlug]/spaces/[spaceSlug].vue
+++ b/src/pages/[locale]/buildings/[buildingSlug]/spaces/[spaceSlug].vue
@@ -19,7 +19,7 @@
       :space="space"
       :associated-spaces="associatedSpaces"
       class="space-detail__card"
-      :is-header="true"
+      is-header
     />
   </section>
 </template>

--- a/src/pages/[locale]/buildings/index.vue
+++ b/src/pages/[locale]/buildings/index.vue
@@ -8,7 +8,7 @@
       v-for="building in buildingsOrdered"
       :key="building.number"
       :building="building"
-      :is-header="true"
+      is-header
     />
   </section>
 </template>

--- a/src/pages/[locale]/buildings/index.vue
+++ b/src/pages/[locale]/buildings/index.vue
@@ -8,6 +8,7 @@
       v-for="building in buildingsOrdered"
       :key="building.number"
       :building="building"
+      :is-header="true"
     />
   </section>
 </template>

--- a/src/pages/[locale]/spaces.vue
+++ b/src/pages/[locale]/spaces.vue
@@ -1,8 +1,5 @@
 <template>
   <section class="default-layout__info">
-    <h2 class="a11y-sr-only">
-      {{ allSpacesTitle }}
-    </h2>
     <SpaceList :spaces="spacesStore.filteredSpaces" />
   </section>
 </template>


### PR DESCRIPTION
# Changes

Makes sure all headings are of the correct level.

# Associated issue

Partly resolves https://trello.com/c/C9CYUm8O/63-accessibility-improvements-for-spacefinder-app-and-map

# How to test

1. Open preview link.
2. Check if the heading level structure makes sense on every page (for example, use the [headingsMap](https://chrome.google.com/webstore/detail/headingsmap/flbjommegcjonpdmenkdiocclhjacmbi) Chrome plugin).

# Checklist

- [x] I have performed a self-review of my own work
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have notified a reviewer
