### PR TITLE
Give links of building and space cards a clearer name for assistive technology

### DIFF
--- a/src/components/BuildingCard/BuildingCard.vue
+++ b/src/components/BuildingCard/BuildingCard.vue
@@ -2,6 +2,7 @@
   <NuxtLink
     :to="$localePath('/buildings/:buildingSlug', { building })"
     class="building-card card"
+    :aria-label="`${building.name} (${building.abbreviation})`"
   >
     <BuildingImage
       :building="building"

--- a/src/components/SpaceList/SpaceList.vue
+++ b/src/components/SpaceList/SpaceList.vue
@@ -28,6 +28,7 @@
         <NuxtLink
           :to="$localePath('/buildings/:buildingSlug/spaces/:spaceSlug', { space })"
           class="space-list__link"
+          :aria-label="`${space.name} (${space.roomId})`"
         >
           <SpaceCard
             :space="space"


### PR DESCRIPTION
# Changes

Makes sure that the link names of the space card and building card that are reported to the accessibility tree make sense to the user, instead of reading the  complete content of the card.

# Associated issue

Partly resolves https://trello.com/c/C9CYUm8O/63-accessibility-improvements-for-spacefinder-app-and-map

# How to test

1. Open preview link.
2. The links reported in the accessibility tree for a building card should be of the following format: BUILDING NAME (BUILDING ABBREVIATION).
3. The links reported in the accessibility tree for a space card should be of the following format: SPACE NAME (ROOM ID).

# Checklist

- [x] I have performed a self-review of my own work
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have notified a reviewer
