### PR TITLE
Disable tooltips on focus to improve a11y

### DIFF
--- a/src/components/BuildingMeta/BuildingMeta.vue
+++ b/src/components/BuildingMeta/BuildingMeta.vue
@@ -5,6 +5,7 @@
         :delay="0"
         :overflow-padding="4"
         :instant-move="true"
+        :triggers="['hover', 'click']"
       >
         <div class="building-meta__item-content">
           <SvgIcon

--- a/src/components/OccupancyIndicator/OccupancyIndicator.vue
+++ b/src/components/OccupancyIndicator/OccupancyIndicator.vue
@@ -5,6 +5,7 @@
         :delay="0"
         :overflow-padding="4"
         :instant-move="true"
+        :triggers="['hover', 'click']"
       >
         <SvgIcon
           :name="`facility-occupancy.${occupancyKey}-icon`"

--- a/src/components/SpaceCard/SpaceCard.vue
+++ b/src/components/SpaceCard/SpaceCard.vue
@@ -49,6 +49,7 @@
               :delay="0"
               :overflow-padding="4"
               :instant-move="true"
+              :triggers="['hover', 'click']"
             >
               <div>
                 <SvgIcon

--- a/src/components/SpaceFacilities/SpaceFacilities.vue
+++ b/src/components/SpaceFacilities/SpaceFacilities.vue
@@ -9,6 +9,7 @@
         :delay="0"
         :overflow-padding="4"
         :instant-move="true"
+        :triggers="['hover', 'click']"
       >
         <SvgIcon
           :name="getIconName(facility)"
@@ -17,7 +18,6 @@
         />
         <template #popper>
           {{ $t(facility) }}
-          <!-- trigger: 'hover click focus', -->
         </template>
       </Tooltip>
 
@@ -36,6 +36,7 @@
         :delay="0"
         :overflow-padding="4"
         :instant-move="true"
+        :triggers="['hover', 'click']"
       >
         <SvgIcon
           name="seat-icon"
@@ -44,7 +45,6 @@
         />
         <template #popper>
           {{ seatsDescription }}
-          <!-- trigger: 'hover click focus', -->
         </template>
       </Tooltip>
     </li>


### PR DESCRIPTION
# Changes

This disables the tooltips on focus, to prevent a large amount of tabbing through the spaces list.

# Associated issue

Partly resolves https://trello.com/c/C9CYUm8O/63-accessibility-improvements-for-spacefinder-app-and-map.

# How to test

1. Open preview link.
2. A space card and building card should still have tooltips on hover, but not on focus.

# Checklist

- [x] I have performed a self-review of my own work
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have notified a reviewer
