### PR TITLE
Hide all svg’s from the accessibility tree

### DIFF
--- a/src/components/OccupancyIndicator/OccupancyIndicator.vue
+++ b/src/components/OccupancyIndicator/OccupancyIndicator.vue
@@ -9,7 +9,6 @@
         <SvgIcon
           :name="`facility-occupancy.${occupancyKey}-icon`"
           class="occupancy-indicator__icon"
-          :alt="$t(`occupancy.${occupancyKey}`)"
         />
         <template #popper>
           {{ $t("occupancy") }}: {{ $t(`occupancy.${occupancyKey}`) }}

--- a/src/components/SpaceFacilities/SpaceFacilities.vue
+++ b/src/components/SpaceFacilities/SpaceFacilities.vue
@@ -13,7 +13,6 @@
         <SvgIcon
           :name="getIconName(facility)"
           class="space-facility__icon"
-          :alt="$t(facility)"
         />
         <template #popper>
           {{ $t(facility) }}

--- a/src/components/SvgIcon/SvgIcon.vue
+++ b/src/components/SvgIcon/SvgIcon.vue
@@ -1,5 +1,5 @@
 <template>
-  <svg>
+  <svg aria-hidden="true">
     <use :xlink:href="`#${props.name}`" />
   </svg>
 </template>


### PR DESCRIPTION
# Changes

This PR prevents assistive technology from announcing SVG icons.

# Associated issue

Partly resolves https://trello.com/c/C9CYUm8O/63-accessibility-improvements-for-spacefinder-app-and-map

# How to test

1. Open preview link.
2. All SVG icons in the app should have the attribute `aria-hidden="true"`.

# Checklist

- [x] I have performed a self-review of my own work
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have notified a reviewer
