### PR TITLE
Bring focus to the top of the page after navigation event to improve accessibility

### DIFF
--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -6,6 +6,11 @@
     <VitePwaManifest />
     <SpriteMap />
 
+    <div
+      tabindex="-1"
+      ref="topOfPage"
+    />
+
     <NotificationBar
       class="default-layout__notification-bar"
       :message="$t('ieNotification')"
@@ -46,11 +51,13 @@
 import { useMapStore } from "~/stores/map";
 
 const route = useRoute();
+const { afterEach } = useRouter();
 const mapStore = useMapStore();
 const { $locale } = useNuxtApp();
 
 const defaultLayout = ref<null | HTMLDivElement>(null);
 const openedMenu = ref<null | string>(null);
+const topOfPage = ref(null);
 
 let spaceSlug: string | string[];
 
@@ -64,6 +71,12 @@ watch(route,
     }
   }
 );
+
+afterEach((from, to) => {
+  if (from.path !== to.path) {
+    topOfPage.value.focus();
+  }
+});
 
 const isSpaceDetailPage = computed(() => route.params.spaceSlug !== undefined)
 

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -57,7 +57,7 @@ const { $locale } = useNuxtApp();
 
 const defaultLayout = ref<null | HTMLDivElement>(null);
 const openedMenu = ref<null | string>(null);
-const topOfPage = ref(null);
+const topOfPage = ref<null | HTMLDivElement>(null);
 
 let spaceSlug: string | string[];
 


### PR DESCRIPTION
# Changes

Currently, the focus will stay on the link the user clicked and then the page will navigate. This is not good for accessibility as the user may get lost.

In this PR the focus will be brought to the top of the page after a page navigation, much like a 'real' website.

# Associated issue

Partly resolves https://trello.com/c/C9CYUm8O/63-accessibility-improvements-for-spacefinder-app-and-map

# How to test

1. Open preview link.
2. Navigate using the items in the navigation, the menu, using the cards and the back button.
3. After every navigation, the first tab should focus on the logo of the Spacefinder.
4. Using the filter button and the menu button should not move the focus to the top of the page.

# Checklist

- [x] I have performed a self-review of my own work
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have notified a reviewer
