### PR TITLE
Show what the number of seats indicates

### DIFF
--- a/src/components/BuildingMeta/BuildingMeta.vue
+++ b/src/components/BuildingMeta/BuildingMeta.vue
@@ -1,23 +1,13 @@
 <template>
   <ul class="flat-list building-meta">
     <li class="building-meta__item">
-      <Tooltip
-        :delay="0"
-        :overflow-padding="4"
-        :instant-move="true"
-        :triggers="['hover', 'click']"
-      >
-        <div class="building-meta__item-content">
-          <SvgIcon
-            name="seat-icon"
-            class="building-meta__seating-icon"
-          />
-          {{ props.seats }} {{ $t('seats') }}
-        </div>
-        <template #popper>
-          {{ $t('capacity') }}: {{ props.seats }} {{ $t('seats') }}
-        </template>
-      </Tooltip>
+      <div class="building-meta__item-content">
+        <SvgIcon
+          name="seat-icon"
+          class="building-meta__seating-icon"
+        />
+        {{ props.seats }} {{ $t('total') }} {{ $t('seats') }}
+      </div>
     </li>
     <li class="building-meta__item">
       <SvgIcon
@@ -30,7 +20,6 @@
 </template>
 
 <script setup lang="ts">
-import { Tooltip } from "floating-vue";
 const props = defineProps<{ seats: number, spaces: number }>();
 </script>
 

--- a/src/components/SpaceCard/SpaceCard.vue
+++ b/src/components/SpaceCard/SpaceCard.vue
@@ -39,39 +39,25 @@
       class="space-card"
     >
       <div class="space-card__left-column">
-        <div class="space-card__header">
-          <component
-            v-if="isHeader"
-            :is="isHeader ? 'h2' : 'h3'"
-            class="space-card__title"
-          >
-            {{ space.name }}
-          </component>
-
-          <div class="space-card__seating">
-            <Tooltip
-              :delay="0"
-              :overflow-padding="4"
-              :instant-move="true"
-              :triggers="['hover', 'click']"
-            >
-              <div>
-                <SvgIcon
-                  name="seat-icon"
-                  class="space-card__seating-icon"
-                />
-                {{ space.seats }}
-              </div>
-              <template #popper>
-                {{ $t('capacity') }}: {{ space.seats }} {{ $t('seats') }}
-              </template>
-            </Tooltip>
-          </div>
-        </div>
+        <component
+          :is="isHeader ? 'h2' : 'h3'"
+          class="space-card__title"
+        >
+          {{ space.name }}
+        </component>
 
         <p class="space-card__description">
           {{ space.roomId }} | {{ space.floor }}
         </p>
+
+        <div class="space-card__seating">
+          <SvgIcon
+            name="seat-icon"
+            class="space-card__seating-icon"
+          />
+          <span class="space-card__seating-number">{{ space.seats }}</span>
+          <span class="space-card__seating-label">{{ $t('total') }} {{ $t('seats') }}</span>
+        </div>
 
         <SpaceFacilities
           :facilities="space.facilities"
@@ -128,7 +114,6 @@
 </template>
 
 <script setup lang="ts">
-import { Tooltip } from "floating-vue";
 import { useRouter } from 'vue-router';
 import { watch } from 'vue';
 
@@ -265,13 +250,6 @@ defineExpose({
   justify-content: flex-end;
 }
 
-.space-card__header {
-  display: flex;
-  justify-content: space-between;
-  gap: var(--spacing-half);
-  font-weight: bold;
-}
-
 .space-card__title {
   margin-bottom: var(--spacing-quarter);
   font-size: var(--font-size-default);
@@ -282,6 +260,7 @@ defineExpose({
 
 .space-card__seating {
   margin-top: -.1rem;
+  font-weight: bold;
   white-space: nowrap;
 }
 
@@ -290,6 +269,16 @@ defineExpose({
   width: 16px;
   height: 16px;
   vertical-align: middle;
+}
+
+.space-card__seating-number {
+  margin-left: calc(.5 * var(--spacing-quarter));
+  margin-right: var(--spacing-quarter);
+}
+
+.space-card__seating-label {
+  font-size: var(--font-size-smaller);
+  font-weight: normal;
 }
 
 .space-card__description {

--- a/src/data/en/messages.json
+++ b/src/data/en/messages.json
@@ -91,6 +91,7 @@
   "th": "Thursday",
   "title": "Spacefinder",
   "today": "Today",
+  "total": "total",
   "tu": "Tuesday",
   "we": "Wednesday",
   "whiteBoard": "white board",

--- a/src/data/nl/messages.json
+++ b/src/data/nl/messages.json
@@ -92,6 +92,7 @@
   "title": "Spacefinder",
   "tu": "dinsdag",
   "today": "vandaag",
+  "total": "totale",
   "we": "woensdag",
   "whiteBoard": "whiteboard",
   "amountDevices": "geen apparaten | 1 apparaat | {amount} apparaten",


### PR DESCRIPTION
# Changes

Adds more information next to the number of seats indicating that the number means the total of seats.

# Associated issue

Resolves https://trello.com/c/GULXfjkE/120-verduidelijken-van-het-aantal-zitplaatsen-in-totaal-beschikbaar-of-nu-nog-beschikbaar

# How to test

1. Open preview link.
2. Go to the object overview page, object detail page, space overview page & space detail page.
3. Every item should have the number of seats with a descriptive text next to it.

# Checklist

- [x] I have performed a self-review of my own work
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have notified a reviewer
