### PR TITLE
Add notification panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ src/data/rooms.json
 src/data/spaces.json
 src/data/infopage.json
 src/data/feedbackpage.json
+src/data/notification.json

--- a/mock/cms/notification.json
+++ b/mock/cms/notification.json
@@ -1,0 +1,9 @@
+{
+  "showNotification": false,
+  "nl": {
+    "body": "<p>De Spacefinder is nog in ontwikkeling.</p>"
+  },
+  "en": {
+    "body": "<p>The Spacefinder is currently in development.</p>"
+  }
+}

--- a/mock/cms/notification.json
+++ b/mock/cms/notification.json
@@ -1,5 +1,6 @@
 {
   "showNotification": false,
+  "updatedAt": "2023-07-12T12:55:11+02:00",
   "nl": {
     "body": "<p>De Spacefinder is nog in ontwikkeling.</p>"
   },

--- a/scripts/data/cms/index.ts
+++ b/scripts/data/cms/index.ts
@@ -64,6 +64,7 @@ export function getNotificationFromCms(): Promise<DatoNotification> {
     `{
       notification {
         showNotification
+        updatedAt
         _allBodyLocales {
           locale,
           value
@@ -102,7 +103,8 @@ export interface DatoInfoPage {
 }
 
 export interface DatoNotification {
-  showNotification: Boolean[];
+  showNotification: boolean;
+  updatedAt: string;
   _allBodyLocales: DatoLocalizedContent[];
 }
 
@@ -126,6 +128,7 @@ export function convertCmsInfo(info: DatoInfoPage) {
 export function convertCmsNotification(info: DatoNotification) {
   return {
     showNotification: info.showNotification,
+    updatedAt: info.updatedAt,
     nl: {
       body:
         info._allBodyLocales.find((item) => item.locale === "nl")?.value ?? "",

--- a/scripts/data/cms/index.ts
+++ b/scripts/data/cms/index.ts
@@ -56,6 +56,24 @@ export function getPageFromCms(pageName: string): Promise<DatoInfoPage> {
   );
 }
 
+export function getNotificationFromCms(): Promise<DatoNotification> {
+  if (mockDataEnabled)
+    return import("../../../mock/cms/notification.json").then((info) => info.default);
+
+  return getFromDato(
+    `{
+      notification {
+        showNotification
+        _allBodyLocales {
+          locale,
+          value
+        }
+      }
+    }`,
+    'notification'
+  );
+}
+
 export function getSpacesDataFromCms() {
   if (mockDataEnabled)
     return import("../../../mock/cms/spaces.json").then((info) => info.default);
@@ -83,6 +101,11 @@ export interface DatoInfoPage {
   _allBodyLocales: DatoLocalizedContent[];
 }
 
+export interface DatoNotification {
+  showNotification: Boolean[];
+  _allBodyLocales: DatoLocalizedContent[];
+}
+
 export function convertCmsInfo(info: DatoInfoPage) {
   return {
     nl: {
@@ -98,4 +121,18 @@ export function convertCmsInfo(info: DatoInfoPage) {
         info._allBodyLocales.find((item) => item.locale === "en")?.value ?? "",
     },
   };
+}
+
+export function convertCmsNotification(info: DatoNotification) {
+  return {
+    showNotification: info.showNotification,
+    nl: {
+      body:
+        info._allBodyLocales.find((item) => item.locale === "nl")?.value ?? "",
+    },
+    en: {
+      body:
+        info._allBodyLocales.find((item) => item.locale === "en")?.value ?? "",
+    },
+  }
 }

--- a/scripts/data/index.ts
+++ b/scripts/data/index.ts
@@ -4,9 +4,11 @@ import fs from "node:fs/promises";
 import { getData as getDataFromCsv, transform } from "./csv/index";
 import {
   getBuildingsDataFromCms,
+  getNotificationFromCms,
   getPageFromCms,
   getSpacesDataFromCms,
   convertCmsInfo,
+  convertCmsNotification,
 } from "./cms/index";
 import addOpeningHours from "./exchange/index";
 import {
@@ -47,9 +49,16 @@ function preparePage(name: string) {
   );
 }
 
+function prepareNotification() {
+  return getNotificationFromCms().then((content) =>
+    writeFile('notification', convertCmsNotification(content))
+  );
+}
+
 Promise.all([
   prepareSpaces(csvPath),
   ...["infoPage", "feedbackPage"].map(preparePage),
+  prepareNotification(),
 ])
   .then(() => console.info("Wrote data for spaces, buildings and CMS"))
   .catch(({ message }) =>

--- a/src/components/NotificationBar/NotificationBar.vue
+++ b/src/components/NotificationBar/NotificationBar.vue
@@ -16,8 +16,10 @@ defineProps<{ message: string }>();
   position: absolute;
   padding: var(--spacing-default);
   bottom: var(--spacing-default);
-  left: var(--spacing-default);
+  left: 50%;
+  transform: translateX(-50%);
   width: calc(100% - var(--spacing-double));
+  max-width: 800px;
   background: var(--brand-secondary-color);
   border: 1px solid transparent;
   box-shadow: var(--shadow-small);
@@ -28,8 +30,6 @@ defineProps<{ message: string }>();
 @media (min-width: 700px) {
   .notification-bar {
     bottom: var(--spacing-double);
-    left: var(--spacing-double);
-    width: calc(100% - 2 * var(--spacing-double));
   }
 }
 </style>

--- a/src/components/NotificationPanel/NotificationPanel.vue
+++ b/src/components/NotificationPanel/NotificationPanel.vue
@@ -51,12 +51,15 @@ function closePanel() {
   z-index: var(--layer--popup);
   position: absolute;
   display: flex;
+  gap: var(--spacing-default);
   justify-content: space-between;
   align-items: flex-start;
   padding: var(--spacing-default) var(--spacing-three-quarter) var(--spacing-default) var(--spacing-default);
   bottom: var(--spacing-default);
-  left: var(--spacing-default);
+  left: 50%;
+  transform: translateX(-50%);
   width: calc(100% - var(--spacing-double));
+  max-width: 800px;
   background: var(--brand-secondary-color);
   border: 1px solid transparent;
   box-shadow: var(--shadow-small);
@@ -64,17 +67,15 @@ function closePanel() {
   line-height: 1.3;
 }
 
-.notification-panel__content {
-  max-width: 800px;
-  align-self: center;
-}
-
 @media (min-width: 700px) {
   .notification-panel {
     bottom: var(--spacing-double);
-    left: var(--spacing-double);
-    width: calc(100% - 2 * var(--spacing-double));
   }
+}
+
+.notification-panel__content {
+  max-width: 800px;
+  align-self: center;
 }
 </style>
   

--- a/src/components/NotificationPanel/NotificationPanel.vue
+++ b/src/components/NotificationPanel/NotificationPanel.vue
@@ -32,22 +32,32 @@ function closePanel() {
 @import "../app-core/variables.css";
 
 .notification-panel {
+  z-index: var(--layer--popup);
+  position: absolute;
   display: flex;
   justify-content: space-between;
-  align-items: center;
-  padding: var(--spacing-three-quarter) var(--spacing-half) var(--spacing-three-quarter) var(--spacing-default);
+  align-items: flex-start;
+  padding: var(--spacing-default) var(--spacing-three-quarter) var(--spacing-default) var(--spacing-default);
+  bottom: var(--spacing-default);
+  left: var(--spacing-default);
+  width: calc(100% - var(--spacing-double));
   background: var(--brand-secondary-color);
+  border: 1px solid transparent;
+  box-shadow: var(--shadow-small);
   color: var(--background-color);
-  line-height: 1.2;
+  line-height: 1.3;
 }
 
 .notification-panel__content {
   max-width: 800px;
+  align-self: center;
 }
 
 @media (min-width: 700px) {
   .notification-panel {
-    padding: var(--spacing-three-quarter) var(--spacing-default);
+    bottom: var(--spacing-double);
+    left: var(--spacing-double);
+    width: calc(100% - 2 * var(--spacing-double));
   }
 }
 </style>

--- a/src/components/NotificationPanel/NotificationPanel.vue
+++ b/src/components/NotificationPanel/NotificationPanel.vue
@@ -1,0 +1,54 @@
+<template>
+  <div class="notification-panel">
+    <div
+      v-html="message"
+      class="notification-panel__content"
+    />
+
+    <button
+      type="button"
+      class="button button--navigation"
+      @click="closePanel"
+    >
+      <SvgIcon
+        name="close-icon"
+        class="button--navigation__icon"
+      />
+
+      {{ $t("close") }}
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{ message: string }>();
+
+function closePanel() {
+  console.log('close panel');
+}
+</script>
+
+<style>
+@import "../app-core/variables.css";
+
+.notification-panel {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--spacing-three-quarter) var(--spacing-half) var(--spacing-three-quarter) var(--spacing-default);
+  background: var(--brand-secondary-color);
+  color: var(--background-color);
+  line-height: 1.2;
+}
+
+.notification-panel__content {
+  max-width: 800px;
+}
+
+@media (min-width: 700px) {
+  .notification-panel {
+    padding: var(--spacing-three-quarter) var(--spacing-default);
+  }
+}
+</style>
+  

--- a/src/components/NotificationPanel/NotificationPanel.vue
+++ b/src/components/NotificationPanel/NotificationPanel.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="notification-panel">
+  <div
+    v-if="showPanel"
+    class="notification-panel"
+  >
     <div
       v-html="message"
       class="notification-panel__content"
@@ -21,10 +24,23 @@
 </template>
 
 <script setup lang="ts">
-defineProps<{ message: string }>();
+import Cookie from "js-cookie";
+
+const props = defineProps<{ showNotification: boolean, timestamp: string, message: string, }>();
+
+const showPanel = ref(false);
+
+onMounted(() => {
+  const cookieNotificationTimestamp = Cookie.get('notification-timestamp');
+
+  if (props.showNotification && cookieNotificationTimestamp !== props.timestamp) {
+    showPanel.value = true;
+  }
+});
 
 function closePanel() {
-  console.log('close panel');
+  Cookie.set('notification-timestamp', props.timestamp);
+  showPanel.value = false;
 }
 </script>
 

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -11,6 +11,11 @@
       ref="topOfPage"
     />
 
+    <NotificationPanel
+      v-if="notification.showNotification"
+      :message="notificationBody"
+    />
+
     <NotificationBar
       class="default-layout__notification-bar"
       :message="$t('ieNotification')"
@@ -49,6 +54,7 @@
 
 <script setup lang="ts">
 import { useMapStore } from "~/stores/map";
+import notification from "../data/notification.json";
 
 const route = useRoute();
 const { afterEach } = useRouter();
@@ -79,6 +85,8 @@ afterEach((from, to) => {
 });
 
 const isSpaceDetailPage = computed(() => route.params.spaceSlug !== undefined)
+
+const notificationBody = computed(() => notification[$locale.value].body)
 
 const onResizeDebounce = useDebounceFn(onResize, 200);
 

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -11,14 +11,15 @@
       ref="topOfPage"
     />
 
-    <NotificationPanel
-      v-if="notification.showNotification"
-      :message="notificationBody"
-    />
-
     <NotificationBar
       class="default-layout__notification-bar"
       :message="$t('ieNotification')"
+    />
+
+    <NotificationPanel
+      :show-notification="notification.showNotification"
+      :timestamp="notification.updatedAt"
+      :message="notificationBody"
     />
 
     <AppHeader


### PR DESCRIPTION
# Changes

Adds a dismissible notification panel to the website. The content of this panel can be edited in DatoCMS. The user can dismiss the panel, but when changes are made in the content of the cms, the panel should reappear with the updated content.

# Associated issue

Resolves [https://trello.com/c/oYgBIyqt/2-document-architecture-change-in-decision-log](https://trello.com/c/4OIgwxVY/119-boodschap-homepage-under-construction)

# How to test

1. Open preview link
2. Make sure that the notification is visible.
3. Switching languages will also switch the language in the notification panel.
4. Dismiss the notification and refresh the page; the notification should still be hidden.
5. Update the notification in DatoCMS and check if the notification comes back after building.

# Checklist

- [x] I have performed a self-review of my own work
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have notified a reviewer
