### PR TITLE
Prerender spaces index route to workaround data loading failure

### DIFF
--- a/config/routes.ts
+++ b/config/routes.ts
@@ -12,10 +12,12 @@ export function generateRoutes(
   const routes = [
     "/en/",
     "/en/buildings/",
+    "/en/spaces/",
     "/en/help/",
     "/en/feedback/",
     "/nl/",
     "/nl/gebouwen/",
+    "/nl/ruimtes/",
     "/nl/hulp/",
     "/nl/feedback/",
   ];


### PR DESCRIPTION
Filling the spaces store server-side does not work so to avoid running the broken code prerender the spaces pages.
