### PR TITLE
Add optional notification to space cards

### DIFF
--- a/mock/cms/spaces.json
+++ b/mock/cms/spaces.json
@@ -3,6 +3,16 @@
         "spaceId": "SSP00040",
         "image": {
             "url": "https://www.datocms-assets.com/13828/1683031456-1000.jpeg"
-        }
+        },
+        "_allMessageLocales": [
+          {
+            "locale": "en",
+            "value": "<p><span>EN: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed rhoncus magna a mollis fermentum. Vestibulum non dignissim velit, a semper odio.</span></p>"
+          },
+          {
+            "locale": "nl",
+            "value": "<p><span>NL: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed rhoncus magna a mollis fermentum. Vestibulum non dignissim velit, a semper odio.</span></p>"
+          }
+        ]
     }
 ]

--- a/schema/space.json
+++ b/schema/space.json
@@ -1,110 +1,114 @@
-{
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "space.json",
-  "description": "A study space at TU Delft",
-  "$ref": "#/definitions/space",
-  "definitions": {
-    "space": {
-      "type":"object",
-      "properties": {
-        "spaceId": { "type": "string" },
-        "buildingNumber": { "type":"integer" },
-        "realEstateNumber": { "type": "string" },
-        "roomId": { "type": "string" },
-        "slug": { "type": "string" },
-        "floor": { "type": "string" },
-        "seats": { "type": "integer" },
-        "tables": { "type": "integer" },
-        "latitude": { "type": "number", "description": "geospatial latitude" },
-        "longitude": { "type": "number", "description": "geospatial longitude" },
-        "openingHours": { "$ref": "base.json#/definitions/openingHours", "description": "Opening hours for space" },
-        "facilities": { "$ref": "#/definitions/facilities" },
-        "image": {
-          "$ref": "#/definitions/image"
-        },
-        "i18n": {
-          "type": "object",
-          "properties": {
-            "nl": {
-              "$ref": "#/definitions/dictionary"
-            },
-            "en": {
-              "$ref": "#/definitions/dictionary"
-            }
+  {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "space.json",
+    "description": "A study space at TU Delft",
+    "$ref": "#/definitions/space",
+    "definitions": {
+      "space": {
+        "type":"object",
+        "properties": {
+          "spaceId": { "type": "string" },
+          "buildingNumber": { "type":"integer" },
+          "realEstateNumber": { "type": "string" },
+          "roomId": { "type": "string" },
+          "slug": { "type": "string" },
+          "floor": { "type": "string" },
+          "seats": { "type": "integer" },
+          "tables": { "type": "integer" },
+          "latitude": { "type": "number", "description": "geospatial latitude" },
+          "longitude": { "type": "number", "description": "geospatial longitude" },
+          "openingHours": { "$ref": "base.json#/definitions/openingHours", "description": "Opening hours for space" },
+          "facilities": { "$ref": "#/definitions/facilities" },
+          "image": {
+            "$ref": "#/definitions/image"
           },
-          "required": [
-            "nl",
-            "en"
-          ],
-          "additionalProperties": false
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "spaceId",
-        "buildingNumber",
-        "facilities",
-        "floor",
-        "i18n",
-        "latitude",
-        "longitude",
-        "openingHours",
-        "realEstateNumber",
-        "roomId",
-        "slug",
-        "seats",
-        "tables"
-      ]
-    },
-    "dictionary": {
-      "type": "object",
-      "properties": {
-        "name": { "type": "string" }
-      },
-      "required": [
-        "name"
-      ],
-      "additionalProperties": false
-    },
-    "facilities": {
-      "type": "object",
-      "properties": {
-        "adjustableChairs": { "type": "boolean" },
-        "quietness": {
-          "type": "string",
-          "enum": ["silent", "quiet", "noisy"]
+          "message": {
+            "en": { "type": "string" },
+            "nl": { "type": "string" }
+          },
+          "i18n": {
+            "type": "object",
+            "properties": {
+              "nl": {
+                "$ref": "#/definitions/dictionary"
+              },
+              "en": {
+                "$ref": "#/definitions/dictionary"
+              }
+            },
+            "required": [
+              "nl",
+              "en"
+            ],
+            "additionalProperties": false
+          }
         },
-        "daylit": { "type": "boolean" },
-        "powerOutlets": { "type": "boolean" },
-        "whiteBoard": { "type": "boolean" },
-        "presentationScreen": { "type": "boolean" },
-        "nearCoffeeMachine": { "type": "boolean" },
-        "nearPrinter": { "type": "boolean" },
-        "nearBathroom": { "type": "boolean" },
-        "numberOfSeats": { "type": "number" }
+        "additionalProperties": false,
+        "required": [
+          "spaceId",
+          "buildingNumber",
+          "facilities",
+          "floor",
+          "i18n",
+          "latitude",
+          "longitude",
+          "openingHours",
+          "realEstateNumber",
+          "roomId",
+          "slug",
+          "seats",
+          "tables"
+        ]
       },
-      "additionalProperties": false,
-      "required":[
-        "adjustableChairs",
-        "quietness",
-        "daylit",
-        "powerOutlets",
-        "whiteBoard",
-        "presentationScreen",
-        "nearCoffeeMachine",
-        "nearPrinter",
-        "nearBathroom"
-      ]
-    },
-    "image": {
-      "type": "object",
-      "properties": {
-        "url": {
-          "type": "string"
-        }
+      "dictionary": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false
       },
-      "required": [ "url" ],
-      "additionalProperties": false
+      "facilities": {
+        "type": "object",
+        "properties": {
+          "adjustableChairs": { "type": "boolean" },
+          "quietness": {
+            "type": "string",
+            "enum": ["silent", "quiet", "noisy"]
+          },
+          "daylit": { "type": "boolean" },
+          "powerOutlets": { "type": "boolean" },
+          "whiteBoard": { "type": "boolean" },
+          "presentationScreen": { "type": "boolean" },
+          "nearCoffeeMachine": { "type": "boolean" },
+          "nearPrinter": { "type": "boolean" },
+          "nearBathroom": { "type": "boolean" },
+          "numberOfSeats": { "type": "number" }
+        },
+        "additionalProperties": false,
+        "required":[
+          "adjustableChairs",
+          "quietness",
+          "daylit",
+          "powerOutlets",
+          "whiteBoard",
+          "presentationScreen",
+          "nearCoffeeMachine",
+          "nearPrinter",
+          "nearBathroom"
+        ]
+      },
+      "image": {
+        "type": ["object", "null"],
+        "properties": {
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [ "url" ],
+        "additionalProperties": false
+      }
     }
   }
-}

--- a/scripts/data/cms/index.ts
+++ b/scripts/data/cms/index.ts
@@ -83,6 +83,10 @@ export function getSpacesDataFromCms() {
     `{
       allSpaces {
         spaceId
+        _allMessageLocales {
+          locale
+          value
+        }
         image {
           url
         }

--- a/scripts/data/csv/index.ts
+++ b/scripts/data/csv/index.ts
@@ -47,7 +47,15 @@ export function transform(
     }
     const space = getSpace(buildingNumber, source);
     const cmsSpace = spacesDataFromCms.find(cmsSpace => cmsSpace.spaceId === space.spaceId);
-    space.image = cmsSpace?.image    
+    space.image = cmsSpace?.image
+
+    if (cmsSpace?._allMessageLocales.every((message) => message.value !== '')) {
+      space.message = {
+        en: cmsSpace?._allMessageLocales?.find(item => item.locale === 'en')!.value,
+        nl: cmsSpace?._allMessageLocales?.find(item => item.locale === 'nl')!.value,
+      }
+    }
+
     spaces.push(space);
 
     if (!(buildingNumber in buildings)) {

--- a/src/components/SpaceCard/SpaceCard.vue
+++ b/src/components/SpaceCard/SpaceCard.vue
@@ -64,6 +64,12 @@
           class="space-card__facilities"
         />
 
+        <div
+          v-if="spaceMessage"
+          class="space-card__message"
+          v-html="spaceMessage"
+        />
+
         <CardStatus
           :opening-hours="space.openingHours"
           class="space-card__open-status"
@@ -129,11 +135,13 @@ const props = defineProps<{
 
 const root = ref(null as null | HTMLDivElement);
 const router = useRouter();
-const { $localePath } = useNuxtApp();
+const { $locale, $localePath } = useNuxtApp();
 
 const currentIndex = ref(0);
+
 const hasAssociatedSpaces = computed(() => props.associatedSpaces && props.associatedSpaces.length > 0);
 
+const spaceMessage = computed(() => props.space.message && props.space.message[$locale.value]);
 
 const goToPreviousSpace = () => {
   if (currentIndex.value > 0) {
@@ -290,6 +298,13 @@ defineExpose({
 
 .space-card__facilities {
   margin-left: -0.2rem;
+}
+
+.space-card__message {
+  margin: var(--spacing-default) 0;
+  padding: var(--spacing-quarter) var(--spacing-half);
+  background-color: var(--neutral-color);
+  font-size: var(--font-size-smaller); 
 }
 
 .space-card__open-status {

--- a/src/types/Space.ts
+++ b/src/types/Space.ts
@@ -53,9 +53,21 @@ export interface RoomBaseRaw {
 export type CsvSpaceData = Omit<
   SpaceI18n,
   "openingHours" | "activeDevices"
-> & { exchangeBuildingId: string; exchangeRoomId: string };
+> & {
+  exchangeBuildingId: string;
+  exchangeRoomId: string;
+  message?: {
+    en: string;
+    nl: string;
+  };
+};
 
 export type CmsSpaceData = Pick<
   SpaceI18n,
   "spaceId" | "image"
->;
+> & {
+  _allMessageLocales: {
+    locale: string;
+    value: string;
+  }[];
+};


### PR DESCRIPTION
# Changes

Adds optional message box to space cards which displays the content saved in DatoCMS.

# Associated issue

Resolves https://trello.com/c/6x4f56r8/124-tekstveld-op-ruimteniveau

# How to test

1. Open preview link.
2. Go to the spaces page. Room "HAL" with number F-1-801 should have a test message.
3. Clicking on that space should display the message also on the space detail page.
4. The test message should adhere to the language toggle.

# Checklist

- [x] I have performed a self-review of my own work
- [x] I have made sure that my PR is easy to review (not too big, includes comments)
- [x] I have notified a reviewer
