### PR TITLE
Partly revert "Materialize latest buildings state view for consistent query performance"

### DIFF
--- a/src/server/api/consume-wifi-data.ts
+++ b/src/server/api/consume-wifi-data.ts
@@ -107,19 +107,13 @@ async function consumeLastBatch({ client }: { client: SupabaseClient }) {
       );
 
       console.time(`Upsert ${uniqueMessages.length} messages`);
-      const { error: upsertError } = await client
+      const { error } = await client
         .from("access_points_latest_states")
         .upsert(uniqueMessages);
       console.timeEnd(`Upsert ${uniqueMessages.length} messages`);
-      if (upsertError) {
-        return console.error(upsertError);
-      }
 
-      console.time("Update buildings_latest_states");
-      const { error: rpcError } = await client.rpc("update_buildings_latest_states");
-      console.timeEnd("Update buildings_latest_states");
-      if (rpcError) {
-        return console.error(rpcError);
+      if (error) {
+        console.error(error);
       }
     },
   });

--- a/supabase/migrations/20230918093829_revert-materialize-buildings.sql
+++ b/supabase/migrations/20230918093829_revert-materialize-buildings.sql
@@ -1,0 +1,16 @@
+drop function
+  if exists "public"."update_buildings_latest_states" ();
+
+drop materialized view
+  if exists "public"."buildings_latest_states";
+
+create or replace view
+  "public"."buildings_latest_states" as
+SELECT
+  access_points_latest_states.building_number,
+  max(access_points_latest_states.updated_at) AS updated_at,
+  sum(access_points_latest_states.device_count) AS device_count
+FROM
+  access_points_latest_states
+GROUP BY
+  access_points_latest_states.building_number;


### PR DESCRIPTION
This partly reverts commit 732b8e065af8153df66c1cc1cfb0e2ce96cebc35.
The materialized view does not have correct ownership and takes too long to update.
